### PR TITLE
v0.3.0: correctness overhaul, ergonomic API, async-trait removal

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,13 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+    - name: Test (sync)
       run: cargo test --verbose
+    - name: Test (async / tokio feature)
+      run: cargo test --features tokio --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@
 Cargo.lock
 /test
 /tmp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+*.swp
+*.swo
+.idea/
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,26 @@
 [package]
 name = "tfio"
-version = "0.1.32"
+version = "0.3.0"
 license = "MIT"
 authors = ["Tanishq Jain <tanishqjain1002@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.85"
 readme = "README.md"
-repository = "https://github.com/GandalfTheGrayOfHell/tfio"
+repository = "https://github.com/MovAh13h/tfio"
 documentation = "https://docs.rs/tfio"
-description = "A library that provides a Transaction-like interface that are traditionally used in databases on FileIO operations."
+description = "A library that provides a Transaction-like interface traditionally used in databases, applied to FileIO operations."
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+tokio = ["dep:tokio"]
 
 [dependencies]
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
+tokio = { version = "1", features = ["rt", "fs", "io-util"], optional = true }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
+
+[[example]]
+name = "async_transaction"
+required-features = ["tokio"]

--- a/README.md
+++ b/README.md
@@ -1,83 +1,145 @@
-# TFIO - Transactional File I/O
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/tfio-header-a-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="assets/tfio-header-a-light.svg">
+  <img alt="TFIO - Transactional File I/O" src="assets/tfio-header-a-light.svg">
+</picture>
 
-![tfio](https://github.com/GandalfTheGrayOfHell/tfio/workflows/tfio/badge.svg)
+![tfio](https://github.com/MovAh13h/tfio/workflows/tfio/badge.svg)
 
-**TFIO** is a library that provides a Transaction-like interface that are traditionally used in databases on FileIO operations. It gives the flexibility to execute and rollback singlular operations as well as transactions on the fly. The library also provides a builder-pattern interface to chain operations and execute them in one go.
+**TFIO** is a library that provides a Transaction-like interface traditionally used in databases, applied to FileIO operations. It gives the flexibility to execute and rollback singular operations as well as transactions on the fly. The library also provides a builder-pattern interface to chain operations and execute them in one go.
 
 ## Features
-1) 100% safe code (thanks to [Rust](https://www.rust-lang.org/))
-2) 10 rollback-able File/Directory operations
-3) Only 1 Third-party dependency
-4) All `Errors` exposed for handling
-5) 100% Tests passing
+
+1. 100% safe code (thanks to [Rust](https://www.rust-lang.org/))
+2. 11 rollback-able File/Directory operations
+3. Transparent cross-filesystem move fallback
+4. Pre-existing destinations backed up and restored on rollback
+5. All `Errors` exposed for handling
+6. 100% tests passing
+7. Optional async support via the `tokio` feature flag
+
+**Minimum Supported Rust Version (MSRV):** 1.85
 
 ## Usage
+
 Import the library in your Rust project:
-```rust
-use tfio::*;
+
+```toml
+[dependencies]
+tfio = "0.3"
 ```
 
 Create a transaction and execute it. If any `Error` is encountered, rollback the entire transaction:
-**Note**: The paths should only use forward slashes (/) and can either begin with disks or relative to the present working directory ie. begin with `./`
+
 ```rust
 use std::io;
 use tfio::*;
 
 fn main() -> io::Result<()> {
-	let temp_dir = "./PATH_TO_TEMP_DIR";
-	let mut tr = Transaction::new()
-				.create_file("./foo.txt")
-				.create_dir("./bar")
-				.write_file("./foo.txt", temp_dir, b"Hello World".to_vec())
-				.move_file("./foo.txt", "./bar/foo.txt")
-				.append_file("./bar/foo.txt", temp_dir, b"dlroW olleH".to_vec());
-	
-	// Execute the transaction
-	if let Err(e) = tr.execute() {
-		eprintln!("Error during execution: {}", e);
-		
-		// All operations can be reverted in reverse-order if `Error` is encountered
-		if let Err(ee) = tr.rollback() {
-			panic!("Error during transaction rollback: {}", ee);
-		}
-	}
-	Ok(())
+    let mut tr = Transaction::new()
+        .create_file("./foo.txt")
+        .create_dir("./bar")
+        .write_file("./foo.txt", b"Hello World".to_vec())
+        .move_file("./foo.txt", "./bar/foo.txt")
+        .append_file("./bar/foo.txt", b"dlroW olleH".to_vec());
+
+    if let Err(e) = tr.execute() {
+        eprintln!("Error during execution: {}", e);
+
+        if let Err(ee) = tr.rollback() {
+            panic!("Error during transaction rollback: {}", ee);
+        }
+    }
+    Ok(())
 }
 ```
 
-You can also import single operations to use:
+`Transaction::new()` uses the OS temp directory for backups. To specify a custom backup directory:
+
+```rust
+let mut tr = Transaction::with_temp_dir("./my_tmp")
+    .delete_file("./important.txt")
+    .delete_dir("./logs");
+```
+
+You can also use single operations directly:
+
 ```rust
 use std::io;
 use tfio::{CopyFile, RollbackableOperation};
 
 fn main() -> io::Result<()> {
-	let mut copy_operation = CopyFile::new("./foo.txt", "./bar/baz/foo.txt");
-	
-	// Execute the operation
-	if let Err(e) = copy_operation.execute() {
-		eprintln!("Error during execution: {}", e);
-		
-		// Rollback the operation
-		if let Err(ee) = copy_operation.rollback() {
-			panic!("Error during rollback: {}", ee);
-		}
-	}
-	Ok(())
+    let mut op = CopyFile::new("./foo.txt", "./bar/baz/foo.txt");
+
+    if let Err(e) = op.execute() {
+        eprintln!("Error during execution: {}", e);
+
+        if let Err(ee) = op.rollback() {
+            panic!("Error during rollback: {}", ee);
+        }
+    }
+    Ok(())
 }
 ```
 
-To run tests:
-```shell
-$ git clone https://github.com/GandalfTheGrayOfHell/tfio
-$ cd tfio
-$ cargo test
+## Async Support
+
+Enable the `tokio` feature in `Cargo.toml`:
+
+```toml
+[dependencies]
+tfio = { version = "0.3", features = ["tokio"] }
 ```
 
-**Note:** Some TFIO operations create temporary files and directories in the TEMP_PATH provided. If an operation requires a path to temp dir then it will also require either the `SingleFileOperation` trait or the `DirectoryOperation` trait. Hence import them as per need.
+Then use `AsyncTransaction` which mirrors the sync API:
 
-## Roadmap
-It is unlikely that this project receives any updates. It is supposed to be a building block for a future project and works just enough to get things done. There are a couple of places where this library could use help:
-1) Handling of `Write` buffers
-2) Path normalization
+```rust
+use tfio::AsyncTransaction;
 
-PRs are always appreciated :)
+#[tokio::main]
+async fn main() {
+    let mut tr = AsyncTransaction::new()
+        .create_file("./foo.txt")
+        .write_file("./foo.txt", b"Hello".to_vec())
+        .touch_file("./bar.txt");
+
+    if let Err(e) = tr.execute().await {
+        eprintln!("Error: {}", e);
+        tr.rollback().await.expect("Rollback failed");
+    }
+}
+```
+
+## Available Operations
+
+| Operation | Sync | Async |
+|-----------|------|-------|
+| `CreateFile` | ✓ | ✓ |
+| `CreateDirectory` | ✓ | ✓ |
+| `DeleteFile` | ✓ | ✓ |
+| `DeleteDirectory` | ✓ | ✓ |
+| `CopyFile` | ✓ | ✓ |
+| `CopyDirectory` | ✓ | ✓ |
+| `MoveFile` | ✓ | ✓ |
+| `MoveDirectory` | ✓ | ✓ |
+| `WriteFile` | ✓ | ✓ |
+| `AppendFile` | ✓ | ✓ |
+| `TouchFile` | ✓ | ✓ |
+
+Move operations automatically fall back to copy-then-delete when source and destination are on different filesystems. Copy and delete operations store a backup in `temp_dir` and restore the original on rollback.
+
+## Notes
+
+- `CreateFile` fails if the target file already exists (use `WriteFile` to overwrite).
+- `rollback()` is safe to call even if `execute()` was never called or failed partway through.
+- All operations that require a backup directory default to the OS temp dir. Use the `::with_temp_dir(...)` constructor to specify a custom location (e.g. same filesystem as the target for atomic moves).
+- Async types (`AsyncTransaction`, `AsyncCopyFile`, etc.) are re-exported directly from the crate root under the `tokio` feature — no need to import from `tfio::async_::*`.
+
+## Running Tests
+
+```shell
+git clone https://github.com/MovAh13h/tfio
+cd tfio
+cargo test                          # sync tests
+cargo test --features tokio         # sync + async tests
+```

--- a/assets/tfio-header-a-dark.svg
+++ b/assets/tfio-header-a-dark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="320" viewBox="0 0 1280 320" font-family="&#34;Space Grotesk&#34;, system-ui, -apple-system, &#34;Segoe UI&#34;, sans-serif">
+  <rect width="1280" height="320" fill="#1c1a17"></rect>
+  <g transform="translate(96 80) scale(1.3333)">
+    <rect x="22" y="22" width="84" height="20" fill="none" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+    <rect x="28" y="50" width="84" height="20" fill="none" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+    <rect x="34" y="78" width="84" height="20" fill="#c25d33" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+  </g>
+  <line x1="338" y1="80" x2="338" y2="240" stroke="#f5f1ea" stroke-opacity="0.15" stroke-width="1"></line>
+  <text x="386" y="184" font-size="128" font-weight="600" fill="#f5f1ea" letter-spacing="-5">tfio</text>
+  <text x="386" y="232" font-size="22" fill="#a39787">A transaction-like interface over file I/O — for Rust.</text>
+</svg>

--- a/assets/tfio-header-a-light.svg
+++ b/assets/tfio-header-a-light.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="320" viewBox="0 0 1280 320" font-family="&#34;Space Grotesk&#34;, system-ui, -apple-system, &#34;Segoe UI&#34;, sans-serif">
+  <rect width="1280" height="320" fill="#f5f1ea"></rect>
+  <g transform="translate(96 80) scale(1.3333)">
+    <rect x="22" y="22" width="84" height="20" fill="none" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+    <rect x="28" y="50" width="84" height="20" fill="none" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+    <rect x="34" y="78" width="84" height="20" fill="#c25d33" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+  </g>
+  <line x1="338" y1="80" x2="338" y2="240" stroke="#1c1a17" stroke-opacity="0.12" stroke-width="1"></line>
+  <text x="386" y="184" font-size="128" font-weight="600" fill="#1c1a17" letter-spacing="-5">tfio</text>
+  <text x="386" y="232" font-size="22" fill="#5a5248">A transaction-like interface over file I/O — for Rust.</text>
+</svg>

--- a/assets/tfio-icon-dark.svg
+++ b/assets/tfio-icon-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="120" viewBox="0 0 140 120">
+  <rect x="22" y="22" width="84" height="20" fill="none" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+  <rect x="28" y="50" width="84" height="20" fill="none" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+  <rect x="34" y="78" width="84" height="20" fill="#c25d33" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+</svg>

--- a/assets/tfio-icon-light.svg
+++ b/assets/tfio-icon-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="120" viewBox="0 0 140 120">
+  <rect x="22" y="22" width="84" height="20" fill="none" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+  <rect x="28" y="50" width="84" height="20" fill="none" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+  <rect x="34" y="78" width="84" height="20" fill="#c25d33" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+</svg>

--- a/assets/tfio-icon-square-dark.svg
+++ b/assets/tfio-icon-square-dark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <rect width="256" height="256" rx="48" fill="#1c1a17"></rect>
+  <g transform="translate(58 68)">
+    <rect x="22" y="22" width="84" height="20" fill="none" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+    <rect x="28" y="50" width="84" height="20" fill="none" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+    <rect x="34" y="78" width="84" height="20" fill="#c25d33" stroke="#f5f1ea" stroke-width="3" rx="3"></rect>
+  </g>
+</svg>

--- a/assets/tfio-icon-square-light.svg
+++ b/assets/tfio-icon-square-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <g transform="translate(58 68)">
+    <rect x="22" y="22" width="84" height="20" fill="none" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+    <rect x="28" y="50" width="84" height="20" fill="none" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+    <rect x="34" y="78" width="84" height="20" fill="#c25d33" stroke="#1c1a17" stroke-width="3" rx="3"></rect>
+  </g>
+</svg>

--- a/examples/async_transaction.rs
+++ b/examples/async_transaction.rs
@@ -1,0 +1,45 @@
+//! Async version of the transaction example — requires the `tokio` feature.
+//!
+//! Run with:
+//!   cargo run --example async_transaction --features tokio
+
+use std::fs;
+use tfio::AsyncTransaction;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let work = tmp.path().join("work");
+    let backups = tmp.path().join("backups");
+    fs::create_dir_all(&work)?;
+
+    fs::write(work.join("template.txt"), b"[template]")?;
+
+    println!("── before ──────────────────────────────────────");
+    println!("  template.txt exists: {}", work.join("template.txt").exists());
+    println!("  deploy/ exists     : {}", work.join("deploy").exists());
+
+    let mut tr = AsyncTransaction::with_temp_dir(&backups)
+        .create_dir(work.join("deploy"))
+        .copy_file(work.join("template.txt"), work.join("deploy/config.txt"))
+        .write_file(work.join("deploy/config.txt"), b"host=localhost\nport=8080\n".to_vec())
+        .create_file(work.join("deploy/pid"))
+        .append_file(work.join("deploy/pid"), b"12345".to_vec())
+        .move_file(work.join("template.txt"), work.join("deploy/template.txt"));
+
+    tr.execute().await?;
+
+    println!("\n── after execute ───────────────────────────────");
+    println!("  template.txt exists       : {}", work.join("template.txt").exists());
+    println!("  deploy/config.txt         : {:?}", fs::read_to_string(work.join("deploy/config.txt"))?);
+    println!("  deploy/pid                : {:?}", fs::read_to_string(work.join("deploy/pid"))?);
+    println!("  deploy/template.txt exists: {}", work.join("deploy/template.txt").exists());
+
+    tr.rollback().await?;
+
+    println!("\n── after rollback ──────────────────────────────");
+    println!("  template.txt exists: {}", work.join("template.txt").exists());
+    println!("  deploy/ exists     : {}", work.join("deploy").exists());
+
+    Ok(())
+}

--- a/examples/rollback_on_error.rs
+++ b/examples/rollback_on_error.rs
@@ -1,0 +1,57 @@
+//! Demonstrates automatic rollback after a mid-transaction failure.
+//!
+//! The transaction modifies two files, then tries to move a file that does not
+//! exist. The move fails, rollback fires, and both files are restored exactly
+//! to their original contents.
+
+use std::fs;
+use tfio::{RollbackableOperation, Transaction};
+
+fn main() -> std::io::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let d = tmp.path();
+
+    // Two pre-existing files with known content.
+    fs::write(d.join("important.txt"), b"original important data")?;
+    fs::write(d.join("log.txt"), b"original log entries")?;
+
+    println!("── before ──────────────────────────────────────");
+    println!("  important.txt : {:?}", read(d, "important.txt"));
+    println!("  log.txt       : {:?}", read(d, "log.txt"));
+
+    // The third operation references a file that doesn't exist — it will fail.
+    let mut tr = Transaction::with_temp_dir(d)
+        .write_file(d.join("important.txt"), b"NEW important data".to_vec())
+        .write_file(d.join("log.txt"), b"NEW log entries".to_vec())
+        .move_file(d.join("ghost.txt"), d.join("dest.txt")); // <── will fail
+
+    println!("\n── executing ───────────────────────────────────");
+    println!("  op 1: write_file important.txt");
+    println!("  op 2: write_file log.txt");
+    println!("  op 3: move_file ghost.txt → dest.txt  (ghost.txt does not exist)");
+
+    match tr.execute() {
+        Ok(()) => println!("  [ok] — unexpected success"),
+        Err(e) => {
+            println!("  [err] op 3 failed: {e}");
+            println!("\n── rolling back ────────────────────────────────");
+            tr.rollback()?;
+            println!("  rollback complete");
+        }
+    }
+
+    println!("\n── after rollback ──────────────────────────────");
+    println!("  important.txt : {:?}", read(d, "important.txt"));
+    println!("  log.txt       : {:?}", read(d, "log.txt"));
+    println!("  dest.txt exists: {}", d.join("dest.txt").exists());
+
+    assert_eq!(read(d, "important.txt"), "original important data");
+    assert_eq!(read(d, "log.txt"), "original log entries");
+    println!("\n  ✓ both files restored to original content");
+
+    Ok(())
+}
+
+fn read(base: &std::path::Path, name: &str) -> String {
+    fs::read_to_string(base.join(name)).unwrap_or_else(|_| "<missing>".into())
+}

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -1,0 +1,76 @@
+//! Demonstrates a successful transaction: create, write, copy, move, append — then rollback to
+//! show the slate is clean.
+
+use std::fs;
+use tfio::{RollbackableOperation, Transaction};
+
+fn main() -> std::io::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let work = tmp.path().join("work");
+    let backups = tmp.path().join("backups");
+    fs::create_dir_all(&work)?;
+
+    // Seed one pre-existing file that will be used as a copy source.
+    fs::write(work.join("template.txt"), b"[template]")?;
+
+    println!("── before ──────────────────────────────────────");
+    print_state(&work);
+
+    // Build the transaction. Backups go in a separate directory so they never
+    // appear alongside the working files.
+    let mut tr = Transaction::with_temp_dir(&backups)
+        .create_dir(work.join("deploy"))
+        .copy_file(work.join("template.txt"), work.join("deploy/config.txt"))
+        .write_file(work.join("deploy/config.txt"), b"host=localhost\nport=8080\n".to_vec())
+        .create_file(work.join("deploy/pid"))
+        .append_file(work.join("deploy/pid"), b"12345".to_vec())
+        .move_file(work.join("template.txt"), work.join("deploy/template.txt"));
+
+    tr.execute()?;
+
+    println!("\n── after execute ───────────────────────────────");
+    print_state(&work);
+
+    tr.rollback()?;
+
+    println!("\n── after rollback ──────────────────────────────");
+    print_state(&work);
+
+    Ok(())
+}
+
+fn print_state(base: &std::path::Path) {
+    for entry in walkdir(base) {
+        let rel = entry.strip_prefix(base).unwrap();
+        if entry.is_file() {
+            let contents = fs::read_to_string(&entry).unwrap_or_else(|_| "<binary>".into());
+            println!("  {}: {:?}", rel.display(), contents.trim());
+        } else {
+            println!("  {}/", rel.display());
+        }
+    }
+    if walkdir(base).is_empty() {
+        println!("  (empty)");
+    }
+}
+
+fn walkdir(base: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut entries = Vec::new();
+    collect(base, base, &mut entries);
+    entries.sort();
+    entries
+}
+
+fn collect(root: &std::path::Path, dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(rd) = fs::read_dir(dir) else { return };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        if path.strip_prefix(root).unwrap().as_os_str().is_empty() {
+            continue;
+        }
+        out.push(path.clone());
+        if path.is_dir() {
+            collect(root, &path, out);
+        }
+    }
+}

--- a/src/append.rs
+++ b/src/append.rs
@@ -1,24 +1,30 @@
-use std::io::{self, Read, Write};
+use std::fs;
 use std::{
-    fs::OpenOptions,
+    env,
+    io,
     path::{Path, PathBuf},
 };
 
 use crate::{RollbackableOperation, SingleFileOperation};
 
-/// Appends data to a file
+/// Appends data to a file.
 pub struct AppendFile {
-    source: PathBuf,
+    path: PathBuf,
     temp_dir: PathBuf,
     backup_path: PathBuf,
     data: Vec<u8>,
 }
 
 impl AppendFile {
-    /// Constructs a new AppendFile operation
-    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T, data: Vec<u8>) -> Self {
+    /// Constructs a new `AppendFile` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(path: S, data: Vec<u8>) -> Self {
+        Self::with_temp_dir(path, env::temp_dir(), data)
+    }
+
+    /// Constructs a new `AppendFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(path: S, temp_dir: T, data: Vec<u8>) -> Self {
         Self {
-            source: source.as_ref().into(),
+            path: path.as_ref().into(),
             temp_dir: temp_dir.as_ref().into(),
             backup_path: PathBuf::new(),
             data,
@@ -29,38 +35,30 @@ impl AppendFile {
 impl RollbackableOperation for AppendFile {
     fn execute(&mut self) -> io::Result<()> {
         self.create_backup_file()?;
-
-        OpenOptions::new()
-            .append(true)
-            .open(self.get_path())?
-            .write_all(&self.data)
+        let mut file = fs::OpenOptions::new().append(true).open(&self.path)?;
+        use std::io::Write;
+        file.write_all(&self.data)
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        let mut buffer = Vec::<u8>::new();
-        let mut backup_file = OpenOptions::new().read(true).open(self.get_backup_path())?;
-
-        backup_file.read_to_end(&mut buffer)?;
-
-        OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(self.get_path())?
-            .write_all(&buffer)
+    fn rollback(&mut self) -> io::Result<()> {
+        if self.backup_path.as_os_str().is_empty() {
+            return Ok(());
+        }
+        fs::copy(&self.backup_path, &self.path).map(|_| ())
     }
 }
 
 impl SingleFileOperation for AppendFile {
     fn get_path(&self) -> &Path {
-        &self.source
+        &self.path
     }
 
     fn get_backup_path(&self) -> &Path {
         &self.backup_path
     }
 
-    fn set_backup_path<S: AsRef<Path>>(&mut self, uuid: S) {
-        self.backup_path = uuid.as_ref().into();
+    fn set_backup_path<S: AsRef<Path>>(&mut self, path: S) {
+        self.backup_path = path.as_ref().into();
     }
 
     fn get_temp_dir(&self) -> &Path {
@@ -70,48 +68,47 @@ impl SingleFileOperation for AppendFile {
 
 impl Drop for AppendFile {
     fn drop(&mut self) {
-        match self.dispose() {
-            Err(e) => eprintln!("{}", e),
-            _ => {}
+        if let Err(e) = self.dispose() {
+            eprintln!("{}", e);
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, File};
-    use std::io;
+    use std::fs;
+
+    use tempfile::tempdir;
 
     use super::*;
 
-    const FILE_SOURCE: &str = "./append.txt";
-    const TEMP_DIR: &str = "./tmp/";
-    const DATA: &[u8] = "Hello World".as_bytes();
+    const DATA: &[u8] = b"Hello World";
 
-    fn setup() -> io::Result<()> {
-        match File::create(FILE_SOURCE) {
-            Ok(_f) => Ok(()),
-            Err(e) => Err(e),
-        }
+    #[test]
+    fn append_file_works() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("append.txt");
+        fs::write(&file_path, DATA).unwrap();
+
+        let mut op = AppendFile::with_temp_dir(&file_path, dir.path(), DATA.to_vec());
+        op.execute().expect("Unable to perform execute");
+
+        let data = fs::read(&file_path).expect("Unable to read file");
+        assert_eq!([DATA, DATA].concat(), data);
+
+        op.rollback().expect("Unable to perform rollback");
+        let data = fs::read(&file_path).expect("Unable to read file");
+        assert_eq!(DATA, data.as_slice());
     }
 
     #[test]
-    #[allow(unused_must_use)]
-    fn append_file_works() {
-        assert_eq!((), setup().expect("Unable to setup test"));
+    fn rollback_before_execute_is_noop() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("append_noop.txt");
+        fs::write(&file_path, DATA).unwrap();
 
-        fs::write(FILE_SOURCE, DATA).expect("Unable to write file");
-
-        let mut op = AppendFile::new(FILE_SOURCE, TEMP_DIR, DATA.to_vec());
-        assert_eq!((), op.execute().expect("Unable to perform execute"));
-
-        let data = fs::read_to_string(FILE_SOURCE).expect("Unable to read file");
-        assert_eq!(String::from_utf8([DATA, DATA].concat()).unwrap(), data);
-
-        assert_eq!((), op.rollback().expect("Unable to perform rollback"));
-        let data = fs::read_to_string(FILE_SOURCE).expect("Unable to read file");
-        assert_eq!(String::from_utf8(DATA.to_vec()).unwrap(), data);
-
-        fs::remove_file(FILE_SOURCE);
+        let mut op = AppendFile::with_temp_dir(&file_path, dir.path(), DATA.to_vec());
+        op.rollback().expect("rollback before execute should be a no-op");
+        assert_eq!(DATA, fs::read(&file_path).unwrap().as_slice());
     }
 }

--- a/src/async_/append.rs
+++ b/src/async_/append.rs
@@ -1,0 +1,59 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWriteExt;
+
+use super::{cleanup_backup_file, create_async_backup_file, AsyncOpFuture, AsyncRollbackableOperation};
+
+/// Asynchronously appends data to a file.
+pub struct AsyncAppendFile {
+    path: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+    data: Vec<u8>,
+}
+
+impl AsyncAppendFile {
+    /// Constructs a new `AsyncAppendFile` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(path: S, data: Vec<u8>) -> Self {
+        Self::with_temp_dir(path, env::temp_dir(), data)
+    }
+
+    /// Constructs a new `AsyncAppendFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(path: S, temp_dir: T, data: Vec<u8>) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            temp_dir: temp_dir.as_ref().into(),
+            backup_path: PathBuf::new(),
+            data,
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncAppendFile {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            self.backup_path = create_async_backup_file(&self.path, &self.temp_dir).await?;
+            let mut file = tokio::fs::OpenOptions::new()
+                .append(true)
+                .open(&self.path)
+                .await?;
+            file.write_all(&self.data).await
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if self.backup_path.as_os_str().is_empty() {
+                return Ok(());
+            }
+            tokio::fs::copy(&self.backup_path, &self.path).await.map(|_| ())
+        })
+    }
+}
+
+impl Drop for AsyncAppendFile {
+    fn drop(&mut self) {
+        cleanup_backup_file(&self.backup_path);
+    }
+}

--- a/src/async_/copy.rs
+++ b/src/async_/copy.rs
@@ -1,0 +1,142 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use super::{
+    async_copy_dir, cleanup_backup_dir, cleanup_backup_file, AsyncOpFuture,
+    AsyncRollbackableOperation,
+};
+
+/// Asynchronously copies a file to the destination.
+///
+/// If the destination already exists it is backed up and restored on rollback.
+pub struct AsyncCopyFile {
+    source: PathBuf,
+    dest: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+    dest_existed: bool,
+}
+
+impl AsyncCopyFile {
+    /// Constructs a new `AsyncCopyFile` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, dest: T) -> Self {
+        Self::with_temp_dir(source, dest, env::temp_dir())
+    }
+
+    /// Constructs a new `AsyncCopyFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>, U: AsRef<Path>>(
+        source: S,
+        dest: T,
+        temp_dir: U,
+    ) -> Self {
+        Self {
+            source: source.as_ref().into(),
+            dest: dest.as_ref().into(),
+            temp_dir: temp_dir.as_ref().into(),
+            backup_path: PathBuf::new(),
+            dest_existed: false,
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncCopyFile {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if tokio::fs::metadata(&self.dest).await.is_ok() {
+                self.dest_existed = true;
+                tokio::fs::create_dir_all(&self.temp_dir).await?;
+                self.backup_path = self.temp_dir.join(Uuid::new_v4().to_string());
+                tokio::fs::copy(&self.dest, &self.backup_path).await?;
+            }
+            tokio::fs::copy(&self.source, &self.dest).await.map(|_| ())
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if self.dest_existed {
+                tokio::fs::copy(&self.backup_path, &self.dest).await.map(|_| ())
+            } else {
+                match tokio::fs::remove_file(&self.dest).await {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    other => other,
+                }
+            }
+        })
+    }
+}
+
+impl Drop for AsyncCopyFile {
+    fn drop(&mut self) {
+        cleanup_backup_file(&self.backup_path);
+    }
+}
+
+/// Asynchronously copies a directory to the destination.
+///
+/// If the destination already exists it is backed up and restored on rollback.
+pub struct AsyncCopyDirectory {
+    source: PathBuf,
+    dest: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+    dest_existed: bool,
+}
+
+impl AsyncCopyDirectory {
+    /// Constructs a new `AsyncCopyDirectory` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, dest: T) -> Self {
+        Self::with_temp_dir(source, dest, env::temp_dir())
+    }
+
+    /// Constructs a new `AsyncCopyDirectory` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>, U: AsRef<Path>>(
+        source: S,
+        dest: T,
+        temp_dir: U,
+    ) -> Self {
+        Self {
+            source: source.as_ref().into(),
+            dest: dest.as_ref().into(),
+            temp_dir: temp_dir.as_ref().into(),
+            backup_path: PathBuf::new(),
+            dest_existed: false,
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncCopyDirectory {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if tokio::fs::metadata(&self.dest).await.is_ok() {
+                self.dest_existed = true;
+                tokio::fs::create_dir_all(&self.temp_dir).await?;
+                self.backup_path = self.temp_dir.join(Uuid::new_v4().to_string());
+                async_copy_dir(&self.dest, &self.backup_path).await?;
+            }
+            async_copy_dir(&self.source, &self.dest).await
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if self.dest_existed {
+                tokio::fs::remove_dir_all(&self.dest).await?;
+                async_copy_dir(&self.backup_path, &self.dest).await
+            } else {
+                match tokio::fs::remove_dir_all(&self.dest).await {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    other => other,
+                }
+            }
+        })
+    }
+}
+
+impl Drop for AsyncCopyDirectory {
+    fn drop(&mut self) {
+        cleanup_backup_dir(&self.backup_path);
+    }
+}

--- a/src/async_/create.rs
+++ b/src/async_/create.rs
@@ -1,0 +1,90 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::{AsyncOpFuture, AsyncRollbackableOperation};
+
+/// Asynchronously creates a new file. Fails if the file already exists.
+pub struct AsyncCreateFile {
+    path: PathBuf,
+}
+
+impl AsyncCreateFile {
+    /// Constructs a new `AsyncCreateFile` operation.
+    pub fn new<S: AsRef<Path>>(path: S) -> Self {
+        Self {
+            path: path.as_ref().into(),
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncCreateFile {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            tokio::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&self.path)
+                .await
+                .map(|_| ())
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            match tokio::fs::remove_file(&self.path).await {
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                other => other,
+            }
+        })
+    }
+}
+
+/// Asynchronously creates a new directory (and any missing parent directories).
+pub struct AsyncCreateDirectory {
+    path: PathBuf,
+    created_root: Option<PathBuf>,
+}
+
+impl AsyncCreateDirectory {
+    /// Constructs a new `AsyncCreateDirectory` operation.
+    pub fn new<S: AsRef<Path>>(path: S) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            created_root: None,
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncCreateDirectory {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            // Walk up to find the topmost new component (sync metadata is fine here).
+            let mut to_create: Option<&Path> = None;
+            let mut cursor: &Path = &self.path;
+            loop {
+                if cursor.exists() {
+                    break;
+                }
+                to_create = Some(cursor);
+                cursor = match cursor.parent() {
+                    Some(p) => p,
+                    None => break,
+                };
+            }
+            self.created_root = to_create.map(|p| p.to_path_buf());
+            tokio::fs::create_dir_all(&self.path).await
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            match &self.created_root {
+                Some(root) => match tokio::fs::remove_dir_all(root).await {
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                    other => other,
+                },
+                None => Ok(()),
+            }
+        })
+    }
+}

--- a/src/async_/delete.rs
+++ b/src/async_/delete.rs
@@ -1,0 +1,109 @@
+use std::env;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::{
+    async_copy_dir, cleanup_backup_dir, cleanup_backup_file, create_async_backup_file,
+    create_async_backup_folder, AsyncOpFuture, AsyncRollbackableOperation,
+};
+
+/// Asynchronously deletes a file (backed up for rollback).
+pub struct AsyncDeleteFile {
+    source: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+}
+
+impl AsyncDeleteFile {
+    /// Constructs a new `AsyncDeleteFile` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(source: S) -> Self {
+        Self::with_temp_dir(source, env::temp_dir())
+    }
+
+    /// Constructs a new `AsyncDeleteFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T) -> Self {
+        Self {
+            source: source.as_ref().into(),
+            temp_dir: temp_dir.as_ref().into(),
+            backup_path: PathBuf::new(),
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncDeleteFile {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            self.backup_path = create_async_backup_file(&self.source, &self.temp_dir).await?;
+            tokio::fs::remove_file(&self.source).await
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if self.backup_path.as_os_str().is_empty() {
+                return Ok(());
+            }
+            tokio::fs::copy(&self.backup_path, &self.source).await.map(|_| ())
+        })
+    }
+}
+
+impl Drop for AsyncDeleteFile {
+    fn drop(&mut self) {
+        cleanup_backup_file(&self.backup_path);
+    }
+}
+
+/// Asynchronously deletes a directory (backed up for rollback).
+pub struct AsyncDeleteDirectory {
+    source: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+}
+
+impl AsyncDeleteDirectory {
+    /// Constructs a new `AsyncDeleteDirectory` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(source: S) -> Self {
+        Self::with_temp_dir(source, env::temp_dir())
+    }
+
+    /// Constructs a new `AsyncDeleteDirectory` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T) -> Self {
+        Self {
+            source: source.as_ref().into(),
+            temp_dir: temp_dir.as_ref().into(),
+            backup_path: PathBuf::new(),
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncDeleteDirectory {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            self.backup_path = create_async_backup_folder(&self.source, &self.temp_dir).await?;
+            tokio::fs::remove_dir_all(&self.source).await
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if self.backup_path.as_os_str().is_empty() {
+                return Ok(());
+            }
+            match tokio::fs::rename(&self.backup_path, &self.source).await {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == io::ErrorKind::CrossesDevices => {
+                    async_copy_dir(&self.backup_path, &self.source).await?;
+                    tokio::fs::remove_dir_all(&self.backup_path).await
+                }
+                Err(e) => Err(e),
+            }
+        })
+    }
+}
+
+impl Drop for AsyncDeleteDirectory {
+    fn drop(&mut self) {
+        cleanup_backup_dir(&self.backup_path);
+    }
+}

--- a/src/async_/mod.rs
+++ b/src/async_/mod.rs
@@ -1,0 +1,271 @@
+use std::future::Future;
+use std::io::{self, Error};
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use uuid::Uuid;
+
+mod append;
+mod copy;
+mod create;
+mod delete;
+mod move_;
+mod touch;
+mod write;
+
+pub use append::AsyncAppendFile;
+pub use copy::{AsyncCopyDirectory, AsyncCopyFile};
+pub use create::{AsyncCreateDirectory, AsyncCreateFile};
+pub use delete::{AsyncDeleteDirectory, AsyncDeleteFile};
+pub use move_::{AsyncMoveDirectory, AsyncMoveFile, AsyncMoveOperation};
+pub use touch::AsyncTouchFile;
+pub use write::AsyncWriteFile;
+
+/// Boxed future type used by [`AsyncRollbackableOperation`].
+pub type AsyncOpFuture<'a> =
+    Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'a>>;
+
+/// Trait that represents an asynchronous rollbackable operation.
+pub trait AsyncRollbackableOperation: Send + Sync {
+    /// Executes the operation.
+    fn execute(&mut self) -> AsyncOpFuture<'_>;
+
+    /// Rolls back the operation.
+    ///
+    /// Safe to call even if `execute` was never called or failed partway through.
+    fn rollback(&mut self) -> AsyncOpFuture<'_>;
+}
+
+/// An asynchronous rollbackable transaction.
+#[must_use = "build then call .execute().await"]
+pub struct AsyncTransaction {
+    ops: Vec<Box<dyn AsyncRollbackableOperation>>,
+    execution_count: usize,
+    temp_dir: PathBuf,
+}
+
+impl AsyncTransaction {
+    /// Constructs a new, empty `AsyncTransaction` using the OS temporary directory for backups.
+    pub fn new() -> Self {
+        Self {
+            ops: vec![],
+            execution_count: 0,
+            temp_dir: std::env::temp_dir(),
+        }
+    }
+
+    /// Constructs a new, empty `AsyncTransaction` with a custom backup directory.
+    pub fn with_temp_dir<P: AsRef<Path>>(temp_dir: P) -> Self {
+        Self {
+            ops: vec![],
+            execution_count: 0,
+            temp_dir: temp_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Adds an [`AsyncCreateFile`] operation.
+    pub fn create_file<S: AsRef<Path>>(mut self, path: S) -> Self {
+        self.ops.push(Box::new(AsyncCreateFile::new(path)));
+        self
+    }
+
+    /// Adds an [`AsyncCreateDirectory`] operation.
+    pub fn create_dir<S: AsRef<Path>>(mut self, path: S) -> Self {
+        self.ops.push(Box::new(AsyncCreateDirectory::new(path)));
+        self
+    }
+
+    /// Adds an [`AsyncAppendFile`] operation.
+    pub fn append_file<S: AsRef<Path>>(mut self, path: S, data: Vec<u8>) -> Self {
+        self.ops
+            .push(Box::new(AsyncAppendFile::with_temp_dir(path, self.temp_dir.clone(), data)));
+        self
+    }
+
+    /// Adds an [`AsyncCopyFile`] operation.
+    pub fn copy_file<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
+        self.ops
+            .push(Box::new(AsyncCopyFile::with_temp_dir(source, dest, self.temp_dir.clone())));
+        self
+    }
+
+    /// Adds an [`AsyncCopyDirectory`] operation.
+    pub fn copy_dir<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
+        self.ops
+            .push(Box::new(AsyncCopyDirectory::with_temp_dir(source, dest, self.temp_dir.clone())));
+        self
+    }
+
+    /// Adds an [`AsyncDeleteFile`] operation.
+    pub fn delete_file<S: AsRef<Path>>(mut self, source: S) -> Self {
+        self.ops
+            .push(Box::new(AsyncDeleteFile::with_temp_dir(source, self.temp_dir.clone())));
+        self
+    }
+
+    /// Adds an [`AsyncDeleteDirectory`] operation.
+    pub fn delete_dir<S: AsRef<Path>>(mut self, source: S) -> Self {
+        self.ops
+            .push(Box::new(AsyncDeleteDirectory::with_temp_dir(source, self.temp_dir.clone())));
+        self
+    }
+
+    /// Adds an [`AsyncMoveFile`] operation.
+    pub fn move_file<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
+        self.ops.push(Box::new(AsyncMoveFile::new(source, dest)));
+        self
+    }
+
+    /// Adds an [`AsyncMoveDirectory`] operation.
+    pub fn move_dir<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
+        self.ops.push(Box::new(AsyncMoveDirectory::new(source, dest)));
+        self
+    }
+
+    /// Adds an [`AsyncWriteFile`] operation.
+    pub fn write_file<S: AsRef<Path>>(mut self, path: S, data: Vec<u8>) -> Self {
+        self.ops
+            .push(Box::new(AsyncWriteFile::with_temp_dir(path, self.temp_dir.clone(), data)));
+        self
+    }
+
+    /// Adds an [`AsyncTouchFile`] operation.
+    pub fn touch_file<S: AsRef<Path>>(mut self, path: S) -> Self {
+        self.ops.push(Box::new(AsyncTouchFile::new(path)));
+        self
+    }
+
+    /// Executes all operations in order, stopping at the first error.
+    pub async fn execute(&mut self) -> io::Result<()> {
+        self.execution_count = 0;
+        for i in 0..self.ops.len() {
+            self.ops[i].execute().await?;
+            self.execution_count += 1;
+        }
+        Ok(())
+    }
+
+    /// Rolls back all successfully-executed operations in reverse order, then resets the counter.
+    pub async fn rollback(&mut self) -> io::Result<()> {
+        for i in (0..self.execution_count).rev() {
+            self.ops[i].rollback().await?;
+        }
+        self.execution_count = 0;
+        Ok(())
+    }
+}
+
+impl Default for AsyncTransaction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared async helpers used by the submodules
+// ---------------------------------------------------------------------------
+
+pub(super) async fn async_copy_dir(from: &Path, to: &Path) -> io::Result<()> {
+    let mut stack = vec![from.to_path_buf()];
+    let output_root = to.to_path_buf();
+    let input_root = from.components().count();
+
+    while let Some(working_path) = stack.pop() {
+        let src: PathBuf = working_path.components().skip(input_root).collect();
+        let dest = if src.components().count() == 0 {
+            output_root.clone()
+        } else {
+            output_root.join(&src)
+        };
+
+        tokio::fs::create_dir_all(&dest).await?;
+
+        let mut entries = tokio::fs::read_dir(&working_path).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            let path = entry.path();
+            if file_type.is_dir() {
+                stack.push(path);
+            } else {
+                match path.file_name() {
+                    Some(filename) => {
+                        tokio::fs::copy(&path, &dest.join(filename)).await?;
+                    }
+                    None => {
+                        return Err(Error::other("could not extract filename from path"))
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn create_async_backup_file(
+    source: &Path,
+    temp_dir: &Path,
+) -> io::Result<PathBuf> {
+    tokio::fs::create_dir_all(temp_dir).await?;
+    let backup_path = temp_dir.join(Uuid::new_v4().to_string());
+    tokio::fs::copy(source, &backup_path).await?;
+    Ok(backup_path)
+}
+
+pub(super) async fn create_async_backup_folder(
+    source: &Path,
+    temp_dir: &Path,
+) -> io::Result<PathBuf> {
+    tokio::fs::create_dir_all(temp_dir).await?;
+    let backup_path = temp_dir.join(Uuid::new_v4().to_string());
+    async_copy_dir(source, &backup_path).await?;
+    Ok(backup_path)
+}
+
+pub(super) fn cleanup_backup_file(path: &PathBuf) {
+    if !path.as_os_str().is_empty() && path.exists() {
+        if let Err(e) = std::fs::remove_file(path) {
+            eprintln!("{}", e);
+        }
+    }
+}
+
+pub(super) fn cleanup_backup_dir(path: &PathBuf) {
+    if !path.as_os_str().is_empty() && path.exists() {
+        if let Err(e) = std::fs::remove_dir_all(path) {
+            eprintln!("{}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn async_transaction_works() {
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        let mut tr = AsyncTransaction::with_temp_dir(d)
+            .create_file(d.join("file.txt"))
+            .create_file(d.join("for_delete.txt"))
+            .create_dir(d.join("inner/sub"))
+            .create_dir(d.join("for_delete_dir"))
+            .create_dir(d.join("magic_dir"))
+            .write_file(d.join("file.txt"), b"Hello World".to_vec())
+            .append_file(d.join("file.txt"), b"Hello World".to_vec())
+            .copy_file(d.join("file.txt"), d.join("inner/file.txt"))
+            .copy_dir(d.join("magic_dir"), d.join("inner/magic_dir"))
+            .delete_file(d.join("for_delete.txt"))
+            .delete_dir(d.join("for_delete_dir"))
+            .move_file(d.join("inner/file.txt"), d.join("inner/magic_dir/file.txt"))
+            .create_dir(d.join("for_moving"))
+            .move_dir(d.join("for_moving"), d.join("inner/magic_dir/for_moving"))
+            .touch_file(d.join("touched.txt"));
+
+        tr.execute().await.expect("Cannot execute");
+        tr.rollback().await.expect("Cannot rollback");
+    }
+}

--- a/src/async_/move_.rs
+++ b/src/async_/move_.rs
@@ -1,0 +1,74 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::{async_copy_dir, AsyncOpFuture, AsyncRollbackableOperation};
+
+/// Asynchronously moves a file. Type alias for [`AsyncMoveOperation`] for API consistency.
+pub type AsyncMoveFile = AsyncMoveOperation;
+
+/// Asynchronously moves a directory. Type alias for [`AsyncMoveOperation`] for API consistency.
+pub type AsyncMoveDirectory = AsyncMoveOperation;
+
+/// Asynchronous move operation (works for both files and directories).
+///
+/// Attempts `tokio::fs::rename` first. On `ErrorKind::CrossesDevices`, falls back to
+/// copy-then-delete transparently. Rollback uses the same strategy in reverse.
+pub struct AsyncMoveOperation {
+    source: PathBuf,
+    dest: PathBuf,
+    was_cross_device: bool,
+}
+
+impl AsyncMoveOperation {
+    /// Constructs a new `AsyncMoveOperation`.
+    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, dest: T) -> Self {
+        Self {
+            source: source.as_ref().into(),
+            dest: dest.as_ref().into(),
+            was_cross_device: false,
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncMoveOperation {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            match tokio::fs::rename(&self.source, &self.dest).await {
+                Ok(()) => {
+                    self.was_cross_device = false;
+                    Ok(())
+                }
+                Err(e) if e.kind() == io::ErrorKind::CrossesDevices => {
+                    self.was_cross_device = true;
+                    async_cross_device_move(&self.source, &self.dest).await
+                }
+                Err(e) => Err(e),
+            }
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            let result = if self.was_cross_device {
+                async_cross_device_move(&self.dest, &self.source).await
+            } else {
+                tokio::fs::rename(&self.dest, &self.source).await
+            };
+            match result {
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                other => other,
+            }
+        })
+    }
+}
+
+async fn async_cross_device_move(from: &Path, to: &Path) -> io::Result<()> {
+    let meta = tokio::fs::metadata(from).await?;
+    if meta.is_dir() {
+        async_copy_dir(from, to).await?;
+        tokio::fs::remove_dir_all(from).await
+    } else {
+        tokio::fs::copy(from, to).await.map(|_| ())?;
+        tokio::fs::remove_file(from).await
+    }
+}

--- a/src/async_/touch.rs
+++ b/src/async_/touch.rs
@@ -1,0 +1,89 @@
+use std::fs::{FileTimes, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use super::{AsyncOpFuture, AsyncRollbackableOperation};
+
+enum TouchState {
+    NotExecuted,
+    Created,
+    Touched {
+        original_accessed: SystemTime,
+        original_modified: SystemTime,
+    },
+}
+
+/// Asynchronously creates a file if absent, or updates its access and modification times to now.
+pub struct AsyncTouchFile {
+    path: PathBuf,
+    state: TouchState,
+}
+
+impl AsyncTouchFile {
+    /// Constructs a new `AsyncTouchFile` operation.
+    pub fn new<S: AsRef<Path>>(path: S) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            state: TouchState::NotExecuted,
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncTouchFile {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            match tokio::fs::metadata(&self.path).await {
+                Ok(meta) => {
+                    let original_accessed = meta.accessed()?;
+                    let original_modified = meta.modified()?;
+                    self.state = TouchState::Touched {
+                        original_accessed,
+                        original_modified,
+                    };
+                    let path = self.path.clone();
+                    tokio::task::spawn_blocking(move || {
+                        OpenOptions::new().write(true).open(&path)?.set_times(
+                            FileTimes::new()
+                                .set_accessed(SystemTime::now())
+                                .set_modified(SystemTime::now()),
+                        )
+                    })
+                    .await
+                    .map_err(io::Error::other)?
+                }
+                Err(_) => {
+                    tokio::fs::File::create(&self.path).await?;
+                    self.state = TouchState::Created;
+                    Ok(())
+                }
+            }
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            match &self.state {
+                TouchState::NotExecuted => Ok(()),
+                TouchState::Created => tokio::fs::remove_file(&self.path).await,
+                TouchState::Touched {
+                    original_accessed,
+                    original_modified,
+                } => {
+                    let path = self.path.clone();
+                    let accessed = *original_accessed;
+                    let modified = *original_modified;
+                    tokio::task::spawn_blocking(move || {
+                        OpenOptions::new().write(true).open(&path)?.set_times(
+                            FileTimes::new()
+                                .set_accessed(accessed)
+                                .set_modified(modified),
+                        )
+                    })
+                    .await
+                    .map_err(io::Error::other)?
+                }
+            }
+        })
+    }
+}

--- a/src/async_/write.rs
+++ b/src/async_/write.rs
@@ -1,0 +1,60 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWriteExt;
+
+use super::{cleanup_backup_file, create_async_backup_file, AsyncOpFuture, AsyncRollbackableOperation};
+
+/// Asynchronously writes data to a file, replacing its existing contents.
+pub struct AsyncWriteFile {
+    path: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+    data: Vec<u8>,
+}
+
+impl AsyncWriteFile {
+    /// Constructs a new `AsyncWriteFile` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(path: S, data: Vec<u8>) -> Self {
+        Self::with_temp_dir(path, env::temp_dir(), data)
+    }
+
+    /// Constructs a new `AsyncWriteFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(path: S, temp_dir: T, data: Vec<u8>) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            temp_dir: temp_dir.as_ref().into(),
+            backup_path: PathBuf::new(),
+            data,
+        }
+    }
+}
+
+impl AsyncRollbackableOperation for AsyncWriteFile {
+    fn execute(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            self.backup_path = create_async_backup_file(&self.path, &self.temp_dir).await?;
+            let mut file = tokio::fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(&self.path)
+                .await?;
+            file.write_all(&self.data).await
+        })
+    }
+
+    fn rollback(&mut self) -> AsyncOpFuture<'_> {
+        Box::pin(async move {
+            if self.backup_path.as_os_str().is_empty() {
+                return Ok(());
+            }
+            tokio::fs::copy(&self.backup_path, &self.path).await.map(|_| ())
+        })
+    }
+}
+
+impl Drop for AsyncWriteFile {
+    fn drop(&mut self) {
+        cleanup_backup_file(&self.backup_path);
+    }
+}

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -1,51 +1,34 @@
 use std::fs;
 use std::{
+    env,
     io,
     path::{Path, PathBuf},
 };
 
-use crate::{copy_dir, DirectoryOperation, RollbackableOperation};
+use uuid::Uuid;
 
-/// Copies a file to destination
+use crate::{copy_dir, RollbackableOperation};
+
+/// Copies a file to the destination.
+///
+/// If the destination already exists its original content is backed up and
+/// restored on rollback. If it did not exist, rollback removes the copy.
 pub struct CopyFile {
     source: PathBuf,
     dest: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+    dest_existed: bool,
 }
 
 impl CopyFile {
-    /// Constructs a new CopyFile operation
+    /// Constructs a new `CopyFile` operation, using the OS temp directory for backups.
     pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, dest: T) -> Self {
-        Self {
-            source: source.as_ref().into(),
-            dest: dest.as_ref().into(),
-        }
-    }
-}
-
-impl RollbackableOperation for CopyFile {
-    fn execute(&mut self) -> io::Result<()> {
-        match fs::copy(&self.source, &self.dest) {
-            Ok(_v) => Ok(()),
-            Err(e) => Err(e),
-        }
+        Self::with_temp_dir(source, dest, env::temp_dir())
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        fs::remove_file(&self.dest)
-    }
-}
-
-/// Copies a directory to destination
-pub struct CopyDirectory {
-    source: PathBuf,
-    dest: PathBuf,
-    backup_path: PathBuf,
-    temp_dir: PathBuf,
-}
-
-impl CopyDirectory {
-    /// Constructs a new CopyDirectory operation
-    pub fn new<S: AsRef<Path>, T: AsRef<Path>, U: AsRef<Path>>(
+    /// Constructs a new `CopyFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>, U: AsRef<Path>>(
         source: S,
         dest: T,
         temp_dir: U,
@@ -55,109 +38,197 @@ impl CopyDirectory {
             dest: dest.as_ref().into(),
             temp_dir: temp_dir.as_ref().into(),
             backup_path: PathBuf::new(),
+            dest_existed: false,
+        }
+    }
+}
+
+impl RollbackableOperation for CopyFile {
+    fn execute(&mut self) -> io::Result<()> {
+        if self.dest.exists() {
+            self.dest_existed = true;
+            fs::create_dir_all(&self.temp_dir)?;
+            self.backup_path = self.temp_dir.join(Uuid::new_v4().to_string());
+            fs::copy(&self.dest, &self.backup_path)?;
+        }
+        fs::copy(&self.source, &self.dest).map(|_| ())
+    }
+
+    fn rollback(&mut self) -> io::Result<()> {
+        if self.dest_existed {
+            fs::copy(&self.backup_path, &self.dest).map(|_| ())
+        } else {
+            match fs::remove_file(&self.dest) {
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                other => other,
+            }
+        }
+    }
+}
+
+impl Drop for CopyFile {
+    fn drop(&mut self) {
+        let bp = &self.backup_path;
+        if !bp.as_os_str().is_empty() && bp.exists() {
+            if let Err(e) = fs::remove_file(bp) {
+                eprintln!("{}", e);
+            }
+        }
+    }
+}
+
+/// Copies a directory to the destination.
+///
+/// If the destination already exists its content is backed up and restored on
+/// rollback. If it did not exist, rollback removes the copy.
+pub struct CopyDirectory {
+    source: PathBuf,
+    dest: PathBuf,
+    temp_dir: PathBuf,
+    backup_path: PathBuf,
+    dest_existed: bool,
+}
+
+impl CopyDirectory {
+    /// Constructs a new `CopyDirectory` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, dest: T) -> Self {
+        Self::with_temp_dir(source, dest, env::temp_dir())
+    }
+
+    /// Constructs a new `CopyDirectory` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>, U: AsRef<Path>>(
+        source: S,
+        dest: T,
+        temp_dir: U,
+    ) -> Self {
+        Self {
+            source: source.as_ref().into(),
+            dest: dest.as_ref().into(),
+            temp_dir: temp_dir.as_ref().into(),
+            backup_path: PathBuf::new(),
+            dest_existed: false,
         }
     }
 }
 
 impl RollbackableOperation for CopyDirectory {
     fn execute(&mut self) -> io::Result<()> {
-        self.create_backup_folder()?;
+        if self.dest.exists() {
+            self.dest_existed = true;
+            fs::create_dir_all(&self.temp_dir)?;
+            self.backup_path = self.temp_dir.join(Uuid::new_v4().to_string());
+            copy_dir(&self.dest, &self.backup_path)?;
+        }
         copy_dir(&self.source, &self.dest)
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        fs::remove_dir_all(&self.dest)
-    }
-}
-
-impl DirectoryOperation for CopyDirectory {
-    fn get_path(&self) -> &Path {
-        &self.source
-    }
-
-    fn get_backup_path(&self) -> &Path {
-        &self.backup_path
-    }
-
-    fn set_backup_path<S: AsRef<Path>>(&mut self, uuid: S) {
-        self.backup_path = uuid.as_ref().into();
-    }
-
-    fn get_temp_dir(&self) -> &Path {
-        &self.temp_dir
+    fn rollback(&mut self) -> io::Result<()> {
+        if self.dest_existed {
+            fs::remove_dir_all(&self.dest)?;
+            copy_dir(&self.backup_path, &self.dest)
+        } else {
+            match fs::remove_dir_all(&self.dest) {
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                other => other,
+            }
+        }
     }
 }
 
 impl Drop for CopyDirectory {
     fn drop(&mut self) {
-        match self.dispose() {
-            Err(e) => eprintln!("{}", e),
-            _ => {}
+        let bp = &self.backup_path;
+        if !bp.as_os_str().is_empty() && bp.exists() {
+            if let Err(e) = fs::remove_dir_all(bp) {
+                eprintln!("{}", e);
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
     use super::*;
-    use std::fs::{self, File};
-    use std::path::Path;
-
-    const FILE_SOURCE: &str = "./copy_file_source.txt";
-    const DEST_DIR: &str = "./copy_file_dir";
-    const FILE_DEST: &str = "./copy_file_dir/copy_file_source.txt";
-
-    fn file_setup() -> std::io::Result<()> {
-        File::create(FILE_SOURCE)?;
-        fs::create_dir(DEST_DIR)
-    }
 
     #[test]
-    #[allow(unused_must_use)]
     fn copy_file_works() {
-        assert_eq!((), file_setup().unwrap());
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("source.txt");
+        let dest_dir = dir.path().join("dest_dir");
+        let dest = dest_dir.join("source.txt");
 
-        let mut op = CopyFile::new(FILE_SOURCE, FILE_DEST);
+        fs::write(&src, b"data").unwrap();
+        fs::create_dir(&dest_dir).unwrap();
 
-        assert_eq!(false, Path::new(FILE_DEST).exists());
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(true, Path::new(FILE_SOURCE).exists());
-        assert_eq!(true, Path::new(FILE_DEST).exists());
+        let mut op = CopyFile::with_temp_dir(&src, &dest, dir.path());
+        assert!(!dest.exists());
+        op.execute().unwrap();
+        assert!(src.exists());
+        assert!(dest.exists());
 
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(true, Path::new(FILE_SOURCE).exists());
-        assert_eq!(false, Path::new(FILE_DEST).exists());
-
-        fs::remove_file(FILE_SOURCE);
-        fs::remove_dir_all(DEST_DIR);
-    }
-
-    const DIR_SOURCE: &str = "./copy_dir_source";
-    const DIR_DIR: &str = "./copy_dest_dir";
-    const DIR_DEST: &str = "./copy_dest_dir/copy_dir_source";
-    const DIR_TEMP: &str = "./tmp";
-
-    fn folder_setup() -> std::io::Result<()> {
-        fs::create_dir(DIR_SOURCE)?;
-        fs::create_dir(DIR_DIR)
+        op.rollback().unwrap();
+        assert!(src.exists());
+        assert!(!dest.exists());
     }
 
     #[test]
-    #[allow(unused_must_use)]
+    fn copy_file_restores_overwritten_dest() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("source.txt");
+        let dest = dir.path().join("dest.txt");
+
+        fs::write(&src, b"new").unwrap();
+        fs::write(&dest, b"original").unwrap();
+
+        let mut op = CopyFile::with_temp_dir(&src, &dest, dir.path());
+        op.execute().unwrap();
+        assert_eq!(b"new", fs::read(&dest).unwrap().as_slice());
+
+        op.rollback().unwrap();
+        assert_eq!(b"original", fs::read(&dest).unwrap().as_slice());
+    }
+
+    #[test]
     fn copy_dir_works() {
-        assert_eq!((), folder_setup().unwrap());
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_dir");
+        let dest = dir.path().join("dest_dir");
 
-        let mut op = CopyDirectory::new(DIR_SOURCE, DIR_DEST, DIR_TEMP);
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("file.txt"), b"hello").unwrap();
 
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(true, Path::new(DIR_SOURCE).exists());
-        assert_eq!(true, Path::new(DIR_DEST).exists());
+        let mut op = CopyDirectory::with_temp_dir(&src, &dest, dir.path());
+        op.execute().unwrap();
+        assert!(src.exists());
+        assert!(dest.exists());
+        assert!(dest.join("file.txt").exists());
 
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(true, Path::new(DIR_SOURCE).exists());
-        assert_eq!(false, Path::new(DIR_DEST).exists());
+        op.rollback().unwrap();
+        assert!(src.exists());
+        assert!(!dest.exists());
+    }
 
-        fs::remove_dir_all(DIR_SOURCE);
-        fs::remove_dir(DIR_DIR);
+    #[test]
+    fn copy_dir_restores_overwritten_dest() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_dir");
+        let dest = dir.path().join("dest_dir");
+
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("new.txt"), b"new").unwrap();
+        fs::create_dir(&dest).unwrap();
+        fs::write(dest.join("original.txt"), b"original").unwrap();
+
+        let mut op = CopyDirectory::with_temp_dir(&src, &dest, dir.path());
+        op.execute().unwrap();
+        assert!(dest.join("new.txt").exists());
+
+        op.rollback().unwrap();
+        assert!(dest.join("original.txt").exists());
+        assert!(!dest.join("new.txt").exists());
     }
 }

--- a/src/create.rs
+++ b/src/create.rs
@@ -1,4 +1,4 @@
-use std::fs::{self, File};
+use std::fs;
 use std::{
     io,
     path::{Path, PathBuf},
@@ -6,13 +6,13 @@ use std::{
 
 use crate::RollbackableOperation;
 
-/// Creates a new file
+/// Creates a new file. Fails if the file already exists.
 pub struct CreateFile {
     path: PathBuf,
 }
 
 impl CreateFile {
-    /// Constructs a new CreateFile operation
+    /// Constructs a new `CreateFile` operation.
     pub fn new<S: AsRef<Path>>(path: S) -> Self {
         Self {
             path: path.as_ref().into(),
@@ -22,70 +22,125 @@ impl CreateFile {
 
 impl RollbackableOperation for CreateFile {
     fn execute(&mut self) -> io::Result<()> {
-        match File::create(&self.path) {
-            Ok(_f) => Ok(()),
-            Err(e) => Err(e),
-        }
+        fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&self.path)
+            .map(|_| ())
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        fs::remove_file(&self.path)
+    fn rollback(&mut self) -> io::Result<()> {
+        match fs::remove_file(&self.path) {
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            other => other,
+        }
     }
 }
 
-/// Creates a new directory
+/// Creates a new directory (and any missing parent directories).
 pub struct CreateDirectory {
     path: PathBuf,
+    created_root: Option<PathBuf>,
 }
 
 impl CreateDirectory {
-    /// Constructs a new CreateDirectory operation
+    /// Constructs a new `CreateDirectory` operation.
     pub fn new<S: AsRef<Path>>(path: S) -> Self {
         Self {
             path: path.as_ref().into(),
+            created_root: None,
         }
     }
 }
 
 impl RollbackableOperation for CreateDirectory {
     fn execute(&mut self) -> io::Result<()> {
+        // Find the topmost path component that doesn't already exist so rollback
+        // removes only what this operation created, not pre-existing parent dirs.
+        let mut to_create: Option<&Path> = None;
+        let mut cursor: &Path = &self.path;
+        loop {
+            if cursor.exists() {
+                break;
+            }
+            to_create = Some(cursor);
+            cursor = match cursor.parent() {
+                Some(p) => p,
+                None => break,
+            };
+        }
+        self.created_root = to_create.map(|p| p.to_path_buf());
         fs::create_dir_all(&self.path)
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        // TODO: So bad
-        fs::remove_dir_all(&self.path)
+    fn rollback(&mut self) -> io::Result<()> {
+        match &self.created_root {
+            Some(root) => match fs::remove_dir_all(root) {
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                other => other,
+            },
+            None => Ok(()),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::path::Path;
+    use tempfile::tempdir;
 
-    const FILE_SOURCE: &str = "./create_file_source.txt";
+    use super::*;
 
     #[test]
     fn create_file_works() {
-        let mut op = CreateFile::new(FILE_SOURCE);
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("create_file.txt");
 
-        assert_eq!(false, Path::new(FILE_SOURCE).exists());
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(true, Path::new(FILE_SOURCE).exists());
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(false, Path::new(FILE_SOURCE).exists());
+        let mut op = CreateFile::new(&file_path);
+        assert!(!file_path.exists());
+        op.execute().unwrap();
+        assert!(file_path.exists());
+        op.rollback().unwrap();
+        assert!(!file_path.exists());
     }
 
-    const DIR_SOURCE: &str = "./create_dir";
+    #[test]
+    fn create_file_fails_if_exists() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("existing.txt");
+        std::fs::write(&file_path, b"data").unwrap();
+
+        let mut op = CreateFile::new(&file_path);
+        assert!(op.execute().is_err());
+    }
 
     #[test]
     fn create_dir_works() {
-        let mut op = CreateDirectory::new(DIR_SOURCE);
+        let dir = tempdir().unwrap();
+        let new_dir = dir.path().join("create_dir");
 
-        assert_eq!(false, Path::new(DIR_SOURCE).exists());
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(true, Path::new(DIR_SOURCE).exists());
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(false, Path::new(DIR_SOURCE).exists());
+        let mut op = CreateDirectory::new(&new_dir);
+        assert!(!new_dir.exists());
+        op.execute().unwrap();
+        assert!(new_dir.exists());
+        op.rollback().unwrap();
+        assert!(!new_dir.exists());
+    }
+
+    #[test]
+    fn create_dir_nested_rollback_only_removes_created() {
+        let dir = tempdir().unwrap();
+        let parent = dir.path().join("existing_parent");
+        let nested = parent.join("new_leaf");
+
+        std::fs::create_dir_all(&parent).unwrap();
+
+        let mut op = CreateDirectory::new(&nested);
+        op.execute().unwrap();
+        assert!(nested.exists());
+        assert!(parent.exists());
+
+        op.rollback().unwrap();
+        assert!(!nested.exists());
+        assert!(parent.exists());
     }
 }

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,12 +1,13 @@
 use std::fs;
 use std::{
+    env,
     io,
     path::{Path, PathBuf},
 };
 
-use crate::{DirectoryOperation, RollbackableOperation, SingleFileOperation};
+use crate::{copy_dir, DirectoryOperation, RollbackableOperation, SingleFileOperation};
 
-/// Deletes a file
+/// Deletes a file (backed up so it can be restored on rollback).
 pub struct DeleteFile {
     source: PathBuf,
     temp_dir: PathBuf,
@@ -14,8 +15,13 @@ pub struct DeleteFile {
 }
 
 impl DeleteFile {
-    /// Constructs a new DeleteFile operation
-    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T) -> Self {
+    /// Constructs a new `DeleteFile` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(source: S) -> Self {
+        Self::with_temp_dir(source, env::temp_dir())
+    }
+
+    /// Constructs a new `DeleteFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T) -> Self {
         Self {
             source: source.as_ref().into(),
             temp_dir: temp_dir.as_ref().into(),
@@ -27,15 +33,14 @@ impl DeleteFile {
 impl RollbackableOperation for DeleteFile {
     fn execute(&mut self) -> io::Result<()> {
         self.create_backup_file()?;
-
         fs::remove_file(self.get_path())
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        match fs::copy(self.get_backup_path(), self.get_path()) {
-            Ok(_v) => Ok(()),
-            Err(e) => Err(e),
+    fn rollback(&mut self) -> io::Result<()> {
+        if self.backup_path.as_os_str().is_empty() {
+            return Ok(());
         }
+        fs::copy(self.get_backup_path(), self.get_path()).map(|_| ())
     }
 }
 
@@ -48,8 +53,8 @@ impl SingleFileOperation for DeleteFile {
         &self.backup_path
     }
 
-    fn set_backup_path<S: AsRef<Path>>(&mut self, uuid: S) {
-        self.backup_path = uuid.as_ref().into();
+    fn set_backup_path<S: AsRef<Path>>(&mut self, path: S) {
+        self.backup_path = path.as_ref().into();
     }
 
     fn get_temp_dir(&self) -> &Path {
@@ -59,14 +64,13 @@ impl SingleFileOperation for DeleteFile {
 
 impl Drop for DeleteFile {
     fn drop(&mut self) {
-        match self.dispose() {
-            Err(e) => eprintln!("{}", e),
-            _ => {}
+        if let Err(e) = self.dispose() {
+            eprintln!("{}", e);
         }
     }
 }
 
-/// Deletes a directory
+/// Deletes a directory (backed up so it can be restored on rollback).
 pub struct DeleteDirectory {
     source: PathBuf,
     backup_path: PathBuf,
@@ -74,8 +78,13 @@ pub struct DeleteDirectory {
 }
 
 impl DeleteDirectory {
-    /// Constructs a new DeleteDirectory operation
-    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T) -> Self {
+    /// Constructs a new `DeleteDirectory` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(source: S) -> Self {
+        Self::with_temp_dir(source, env::temp_dir())
+    }
+
+    /// Constructs a new `DeleteDirectory` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T) -> Self {
         Self {
             source: source.as_ref().into(),
             temp_dir: temp_dir.as_ref().into(),
@@ -90,8 +99,18 @@ impl RollbackableOperation for DeleteDirectory {
         fs::remove_dir_all(&self.source)
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        fs::rename(self.get_backup_path(), &self.source)
+    fn rollback(&mut self) -> io::Result<()> {
+        if self.backup_path.as_os_str().is_empty() {
+            return Ok(());
+        }
+        match fs::rename(self.get_backup_path(), &self.source) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::CrossesDevices => {
+                copy_dir(self.get_backup_path(), &self.source)?;
+                fs::remove_dir_all(self.get_backup_path())
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -104,8 +123,8 @@ impl DirectoryOperation for DeleteDirectory {
         &self.backup_path
     }
 
-    fn set_backup_path<S: AsRef<Path>>(&mut self, uuid: S) {
-        self.backup_path = uuid.as_ref().into();
+    fn set_backup_path<S: AsRef<Path>>(&mut self, path: S) {
+        self.backup_path = path.as_ref().into();
     }
 
     fn get_temp_dir(&self) -> &Path {
@@ -115,64 +134,45 @@ impl DirectoryOperation for DeleteDirectory {
 
 impl Drop for DeleteDirectory {
     fn drop(&mut self) {
-        match self.dispose() {
-            Err(e) => eprintln!("{}", e),
-            _ => {}
+        if let Err(e) = self.dispose() {
+            eprintln!("{}", e);
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
     use super::*;
-    use std::fs::File;
-    use std::path::Path;
-
-    const FILE_SOURCE: &str = "./delete_file_source";
-    const TEMP_DIR: &str = "./tmp/";
-
-    fn file_setup() -> std::io::Result<()> {
-        match File::create(FILE_SOURCE) {
-            Ok(_f) => Ok(()),
-            Err(e) => Err(e),
-        }
-    }
 
     #[test]
-    #[allow(unused_must_use)]
     fn delete_file_works() {
-        assert_eq!((), file_setup().unwrap());
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("delete_me.txt");
+        fs::write(&file_path, b"data").unwrap();
 
-        let mut op = DeleteFile::new(FILE_SOURCE, TEMP_DIR);
-
-        assert_eq!(true, Path::new(FILE_SOURCE).exists());
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(false, Path::new(FILE_SOURCE).exists());
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(true, Path::new(FILE_SOURCE).exists());
-
-        fs::remove_file(FILE_SOURCE);
-    }
-
-    const DIR_SOURCE: &str = "./delete_dir_source";
-
-    fn dir_setup() -> std::io::Result<()> {
-        fs::create_dir(DIR_SOURCE)
+        let mut op = DeleteFile::with_temp_dir(&file_path, dir.path());
+        assert!(file_path.exists());
+        op.execute().unwrap();
+        assert!(!file_path.exists());
+        op.rollback().unwrap();
+        assert!(file_path.exists());
     }
 
     #[test]
-    #[allow(unused_must_use)]
     fn delete_dir_works() {
-        assert_eq!((), dir_setup().unwrap());
+        let dir = tempdir().unwrap();
+        let target_dir = dir.path().join("delete_me_dir");
+        fs::create_dir(&target_dir).unwrap();
 
-        let mut op = DeleteDirectory::new(DIR_SOURCE, TEMP_DIR);
-
-        assert_eq!(true, Path::new(DIR_SOURCE).exists());
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(false, Path::new(DIR_SOURCE).exists());
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(true, Path::new(DIR_SOURCE).exists());
-
-        fs::remove_dir_all(DIR_SOURCE);
+        let mut op = DeleteDirectory::with_temp_dir(&target_dir, dir.path());
+        assert!(target_dir.exists());
+        op.execute().unwrap();
+        assert!(!target_dir.exists());
+        op.rollback().unwrap();
+        assert!(target_dir.exists());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,57 +1,58 @@
-//! TFIO is a library that provides a Transaction-like interface that are traditionally used in databases on FileIO operations. It gives the flexibility to execute and rollback singlular operations as well as transactions on the fly. The library also provides a builder-pattern interface to chain operations and execute them in one go.
+//! TFIO is a library that provides a Transaction-like interface traditionally used in databases,
+//! applied to FileIO operations. It gives the flexibility to execute and rollback singular
+//! operations as well as transactions on the fly. The library also provides a builder-pattern
+//! interface to chain operations and execute them in one go.
 //!
 //! # Examples
 //!
 //! Create a transaction and execute it. If any `Error` is encountered, rollback the entire transaction:
-//! Note: The paths should only use forward slashes (`/`) and can either begin with disks or relative to the present working directory ie. begin with `./`
-//! ```
+//! ```no_run
 //! use std::io;
 //! use tfio::*;
 //!
 //! fn main() -> io::Result<()> {
-//! 	let temp_dir = "./PATH_TO_TEMP_DIR";
-//! 	let mut tr = Transaction::new()
-//! 				.create_file("./foo.txt")
-//! 				.create_dir("./bar")
-//! 				.write_file("./foo.txt", temp_dir, b"Hello World".to_vec())
-//! 				.move_file("./foo.txt", "./bar/foo.txt")
-//! 				.append_file("./bar/foo.txt", temp_dir, b"dlroW olleH".to_vec());
+//!     let mut tr = Transaction::new()
+//!         .create_file("./foo.txt")
+//!         .create_dir("./bar")
+//!         .write_file("./foo.txt", b"Hello World".to_vec())
+//!         .move_file("./foo.txt", "./bar/foo.txt")
+//!         .append_file("./bar/foo.txt", b"dlroW olleH".to_vec());
 //!
-//! 	// Execute the transaction
-//! 	if let Err(e) = tr.execute() {
-//! 		eprintln!("Error during execution: {}", e);
+//!     // Execute the transaction
+//!     if let Err(e) = tr.execute() {
+//!         eprintln!("Error during execution: {}", e);
 //!
-//! 		// All operations can be reverted in reverse-order if `Error` is encountered
-//! 		if let Err(ee) = tr.rollback() {
-//! 			panic!("Error during transaction rollback: {}", ee);
-//! 		}
-//! 	}
-//! 	Ok(())
+//!         // All operations can be reverted in reverse-order if `Error` is encountered
+//!         if let Err(ee) = tr.rollback() {
+//!             panic!("Error during transaction rollback: {}", ee);
+//!         }
+//!     }
+//!     Ok(())
 //! }
 //! ```
 //!
 //! You can also import single operations to use:
-//! ```
+//! ```no_run
 //! use std::io;
 //! use std::fs;
 //! use tfio::{CopyFile, RollbackableOperation};
 //!
 //! fn main() -> io::Result<()> {
-//! 	fs::File::create("./foo.txt")?;
-//! 	fs::create_dir_all("./bar/baz")?;
+//!     fs::File::create("./foo.txt")?;
+//!     fs::create_dir_all("./bar/baz")?;
 //!
-//! 	let mut copy_operation = CopyFile::new("./foo.txt", "./bar/baz/foo.txt");
+//!     let mut copy_operation = CopyFile::new("./foo.txt", "./bar/baz/foo.txt");
 //!
-//! 	// Execute the operation
-//! 	if let Err(e) = copy_operation.execute() {
-//! 		eprintln!("Error during execution: {}", e);
+//!     // Execute the operation
+//!     if let Err(e) = copy_operation.execute() {
+//!         eprintln!("Error during execution: {}", e);
 //!
-//! 		// Rollback the operation
-//! 		if let Err(ee) = copy_operation.rollback() {
-//! 			panic!("Error during rollback: {}", ee);
-//! 		}
-//! 	}
-//! 	Ok(())
+//!         // Rollback the operation
+//!         if let Err(ee) = copy_operation.rollback() {
+//!             panic!("Error during rollback: {}", ee);
+//!         }
+//!     }
+//!     Ok(())
 //! }
 //! ```
 
@@ -62,10 +63,23 @@ mod copy;
 mod create;
 mod delete;
 mod r#move;
+mod touch;
 mod write;
 
-use std::fs::{self, OpenOptions};
-use std::io::{self, Error, ErrorKind, Read, Write};
+/// Async versions of all operations, backed by `tokio::fs`. Enable with the `tokio` feature.
+#[cfg(feature = "tokio")]
+pub mod async_;
+
+#[cfg(feature = "tokio")]
+pub use async_::{
+    AsyncAppendFile, AsyncCopyDirectory, AsyncCopyFile, AsyncCreateDirectory, AsyncCreateFile,
+    AsyncDeleteDirectory, AsyncDeleteFile, AsyncMoveDirectory, AsyncMoveFile, AsyncMoveOperation,
+    AsyncOpFuture, AsyncRollbackableOperation, AsyncTouchFile, AsyncTransaction, AsyncWriteFile,
+};
+
+use std::env;
+use std::fs;
+use std::io::{self, Error};
 use std::path::{Path, PathBuf};
 
 use uuid::Uuid;
@@ -75,160 +89,111 @@ pub use copy::{CopyDirectory, CopyFile};
 pub use create::{CreateDirectory, CreateFile};
 pub use delete::{DeleteDirectory, DeleteFile};
 pub use r#move::{MoveDirectory, MoveFile, MoveOperation};
+pub use touch::TouchFile;
 pub use write::WriteFile;
 
-/// Trait that represents a Rollbackable operation
+/// Trait that represents a rollbackable operation.
 pub trait RollbackableOperation {
-    /// Executes the operation
+    /// Executes the operation.
     fn execute(&mut self) -> io::Result<()>;
 
-    /// Rollbacks the operation
-    fn rollback(&self) -> io::Result<()>;
+    /// Rolls back the operation.
+    ///
+    /// Safe to call even if `execute` was never called or failed partway through.
+    fn rollback(&mut self) -> io::Result<()>;
 }
 
-/// Trait that represents a Directory operation
-pub trait DirectoryOperation: RollbackableOperation + Drop {
-    /// Returns path to source directory
+/// Trait that represents a directory operation.
+pub trait DirectoryOperation: RollbackableOperation {
+    /// Returns the path to the source directory.
     fn get_path(&self) -> &Path;
 
-    /// Returns path to backup directory
-    ///
-    /// Defaults to ""
+    /// Returns the path to the backup directory. Empty if no backup has been created.
     fn get_backup_path(&self) -> &Path;
 
-    /// Sets the backup path
-    fn set_backup_path<S: AsRef<Path>>(&mut self, uuid: S);
+    /// Sets the backup path.
+    fn set_backup_path<S: AsRef<Path>>(&mut self, path: S);
 
-    /// Returns path to temp dir
+    /// Returns the path to the temp dir.
     fn get_temp_dir(&self) -> &Path;
 
-    /// Dispose off resources used by the operation
-    ///
-    /// It should be called inside [Drop](std::ops::Drop)
+    /// Cleans up the backup directory. Should be called from [`Drop`].
     fn dispose(&self) -> io::Result<()> {
-        fs::remove_dir(self.get_backup_path())
+        let bp = self.get_backup_path();
+        if bp.as_os_str().is_empty() || !bp.exists() {
+            return Ok(());
+        }
+        fs::remove_dir_all(bp)
     }
 
-    /// Creates a backup of the source directory
-    ///
-    /// If backup file is successfully created, method should call [set_backup_path](#method.set_backup_path)
+    /// Creates a backup copy of the source directory and records the backup path.
     fn create_backup_folder(&mut self) -> io::Result<()> {
-        fs::create_dir_all(&self.get_temp_dir())?;
-
-        let uuid = Uuid::new_v4();
-        let mut buffer = [b' '; 36];
-
-        uuid.to_hyphenated().encode_lower(&mut buffer);
-
-        let uuid_str = String::from_utf8(buffer.to_vec())
-            .expect(format!("Could not convert buffer to String").as_str());
-        let backup_path = Path::new(&self.get_temp_dir())
-            .join(uuid_str)
-            .to_str()
-            .unwrap()
-            .to_string();
-
+        fs::create_dir_all(self.get_temp_dir())?;
+        let backup_path = self.get_temp_dir().join(Uuid::new_v4().to_string());
         copy_dir(self.get_path(), &backup_path)?;
-
-        self.set_backup_path(&backup_path);
-
+        self.set_backup_path(backup_path);
         Ok(())
     }
 }
 
-/// Trait that represents a single file operation
-pub trait SingleFileOperation: RollbackableOperation + Drop {
-    /// Returns path to source file
+/// Trait that represents a single-file operation.
+pub trait SingleFileOperation: RollbackableOperation {
+    /// Returns the path to the source file.
     fn get_path(&self) -> &Path;
 
-    /// Returns path to backup file
-    ///
-    /// Defaults to ""
+    /// Returns the path to the backup file. Empty if no backup has been created.
     fn get_backup_path(&self) -> &Path;
 
-    /// Sets the backup path
-    fn set_backup_path<S: AsRef<Path>>(&mut self, uuid: S);
+    /// Sets the backup path.
+    fn set_backup_path<S: AsRef<Path>>(&mut self, path: S);
 
-    /// Returns path to temp dir
+    /// Returns the path to the temp dir.
     fn get_temp_dir(&self) -> &Path;
 
-    /// Dispose off resources used by the operation
-    ///
-    /// It should be called inside [Drop](std::ops::Drop)
+    /// Cleans up the backup file. Should be called from [`Drop`].
     fn dispose(&self) -> io::Result<()> {
-        fs::remove_file(self.get_backup_path())
+        let bp = self.get_backup_path();
+        if bp.as_os_str().is_empty() || !bp.exists() {
+            return Ok(());
+        }
+        fs::remove_file(bp)
     }
 
-    /// Creates a backup of the source file
-    ///
-    /// If backup file is successfully created, method should call [set_backup_path](#method.set_backup_path)
+    /// Creates a backup copy of the source file and records the backup path.
     fn create_backup_file(&mut self) -> io::Result<()> {
-        fs::create_dir_all(&self.get_temp_dir())?;
-
-        let uuid = Uuid::new_v4();
-        let mut buffer = [b' '; 36];
-
-        uuid.to_hyphenated().encode_lower(&mut buffer);
-
-        let uuid_str = String::from_utf8(buffer.to_vec())
-            .expect(format!("Could not convert buffer to String").as_str());
-        let backup_path = Path::new(&self.get_temp_dir())
-            .join(uuid_str)
-            .to_str()
-            .unwrap()
-            .to_string();
-
-        let mut buffer = Vec::new();
-        let mut dest_file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(&backup_path)?;
-        let mut source_file = OpenOptions::new().read(true).open(&self.get_path())?;
-
-        source_file.read_to_end(&mut buffer)?;
-        dest_file.write_all(&buffer)?;
+        fs::create_dir_all(self.get_temp_dir())?;
+        let backup_path = self.get_temp_dir().join(Uuid::new_v4().to_string());
+        fs::copy(self.get_path(), &backup_path)?;
         self.set_backup_path(&backup_path);
-
         Ok(())
     }
 }
 
-fn copy_dir<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> io::Result<()> {
-    let mut stack = Vec::new();
-    stack.push(PathBuf::from(from.as_ref()));
-
-    let output_root = PathBuf::from(to.as_ref());
-    let input_root = PathBuf::from(from.as_ref()).components().count();
+pub(crate) fn copy_dir<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> io::Result<()> {
+    let mut stack = vec![from.as_ref().to_path_buf()];
+    let output_root = to.as_ref().to_path_buf();
+    let input_root = from.as_ref().components().count();
 
     while let Some(working_path) = stack.pop() {
         let src: PathBuf = working_path.components().skip(input_root).collect();
-
         let dest = if src.components().count() == 0 {
             output_root.clone()
         } else {
             output_root.join(&src)
         };
 
-        if fs::metadata(&dest).is_err() {
-            fs::create_dir_all(&dest)?;
-        }
+        fs::create_dir_all(&dest)?;
 
-        for entry in fs::read_dir(working_path)? {
-            let path = entry?.path();
-
-            if path.is_dir() {
+        for entry in fs::read_dir(&working_path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if entry.file_type()?.is_dir() {
                 stack.push(path);
             } else {
                 match path.file_name() {
-                    Some(filename) => {
-                        let dest_path = dest.join(filename);
-                        fs::copy(&path, &dest_path)?;
-                    }
+                    Some(filename) => fs::copy(&path, dest.join(filename)).map(|_| ())?,
                     None => {
-                        return Err(Error::new(
-                            ErrorKind::Other,
-                            "Could not extract filename from path",
-                        ))
+                        return Err(Error::other("could not extract filename from path"))
                     }
                 }
             }
@@ -238,162 +203,163 @@ fn copy_dir<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> io::Result<()> {
     Ok(())
 }
 
-/// A rollbackable Transaction
+/// A rollbackable transaction that executes a sequence of [`RollbackableOperation`]s.
+#[must_use = "build then call .execute()"]
 pub struct Transaction {
     ops: Vec<Box<dyn RollbackableOperation>>,
     execution_count: usize,
+    temp_dir: PathBuf,
 }
 
 impl Transaction {
-    /// Constructs a new, empty Transaction
+    /// Constructs a new, empty `Transaction` using the OS temporary directory for backups.
     pub fn new() -> Self {
         Self {
             ops: vec![],
             execution_count: 0,
+            temp_dir: env::temp_dir(),
         }
     }
 
-    /// Adds a [CreateFile](struct.CreateFile.html) operation to the transaction
-    pub fn create_file<S: AsRef<Path>>(mut self, path: S) -> Transaction {
+    /// Constructs a new, empty `Transaction` with a custom backup directory.
+    pub fn with_temp_dir<P: AsRef<Path>>(temp_dir: P) -> Self {
+        Self {
+            ops: vec![],
+            execution_count: 0,
+            temp_dir: temp_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Adds a [`CreateFile`] operation.
+    pub fn create_file<S: AsRef<Path>>(mut self, path: S) -> Self {
         self.ops.push(Box::new(CreateFile::new(path)));
         self
     }
 
-    /// Adds a [CreateDirectory](struct.CreateDirectory.html) operation to the transaction
-    pub fn create_dir<S: AsRef<Path>>(mut self, path: S) -> Transaction {
+    /// Adds a [`CreateDirectory`] operation.
+    pub fn create_dir<S: AsRef<Path>>(mut self, path: S) -> Self {
         self.ops.push(Box::new(CreateDirectory::new(path)));
         self
     }
 
-    /// Adds a [AppendFile](struct.AppendFile.html) operation to the transaction
-    pub fn append_file<S: AsRef<Path>>(
-        mut self,
-        source: S,
-        temp_dir: S,
-        data: Vec<u8>,
-    ) -> Transaction {
+    /// Adds an [`AppendFile`] operation.
+    pub fn append_file<S: AsRef<Path>>(mut self, path: S, data: Vec<u8>) -> Self {
         self.ops
-            .push(Box::new(AppendFile::new(source, temp_dir, data)));
+            .push(Box::new(AppendFile::with_temp_dir(path, self.temp_dir.clone(), data)));
         self
     }
 
-    /// Adds a [CopyFile](struct.CopyFile.html) operation to the transaction
-    pub fn copy_file<S: AsRef<Path>>(mut self, source: S, dest: S) -> Transaction {
-        self.ops.push(Box::new(CopyFile::new(source, dest)));
-        self
-    }
-
-    /// Adds a [CopyDirectory](struct.CopyDirectory.html) operation to the transaction
-    pub fn copy_dir<S: AsRef<Path>>(mut self, source: S, dest: S, temp_dir: S) -> Transaction {
+    /// Adds a [`CopyFile`] operation.
+    pub fn copy_file<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
         self.ops
-            .push(Box::new(CopyDirectory::new(source, dest, temp_dir)));
+            .push(Box::new(CopyFile::with_temp_dir(source, dest, self.temp_dir.clone())));
         self
     }
 
-    /// Adds a [DeleteFile](struct.DeleteFile.html) operation to the transaction
-    pub fn delete_file<S: AsRef<Path>>(mut self, source: S, temp_dir: S) -> Transaction {
-        self.ops.push(Box::new(DeleteFile::new(source, temp_dir)));
-        self
-    }
-
-    /// Adds a [DeleteDirectory](struct.DeleteDirectory.html) operation to the transaction
-    pub fn delete_dir<S: AsRef<Path>>(mut self, source: S, temp_dir: S) -> Transaction {
+    /// Adds a [`CopyDirectory`] operation.
+    pub fn copy_dir<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
         self.ops
-            .push(Box::new(DeleteDirectory::new(source, temp_dir)));
+            .push(Box::new(CopyDirectory::with_temp_dir(source, dest, self.temp_dir.clone())));
         self
     }
 
-    /// Adds a [MoveFile](type.MoveFile.html) operation to the transaction
-    pub fn move_file<S: AsRef<Path>>(mut self, source: S, dest: S) -> Transaction {
+    /// Adds a [`DeleteFile`] operation.
+    pub fn delete_file<S: AsRef<Path>>(mut self, source: S) -> Self {
+        self.ops
+            .push(Box::new(DeleteFile::with_temp_dir(source, self.temp_dir.clone())));
+        self
+    }
+
+    /// Adds a [`DeleteDirectory`] operation.
+    pub fn delete_dir<S: AsRef<Path>>(mut self, source: S) -> Self {
+        self.ops
+            .push(Box::new(DeleteDirectory::with_temp_dir(source, self.temp_dir.clone())));
+        self
+    }
+
+    /// Adds a [`MoveFile`] operation.
+    pub fn move_file<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
         self.ops.push(Box::new(MoveFile::new(source, dest)));
         self
     }
 
-    /// Adds a [MoveDirectory](type.MoveDirectory.html) operation to the transaction
-    pub fn move_dir<S: AsRef<Path>>(mut self, source: S, dest: S) -> Transaction {
+    /// Adds a [`MoveDirectory`] operation.
+    pub fn move_dir<S: AsRef<Path>, T: AsRef<Path>>(mut self, source: S, dest: T) -> Self {
         self.ops.push(Box::new(MoveDirectory::new(source, dest)));
         self
     }
 
-    /// Adds a [WriteFile](struct.WriteFile.html) operation to the transaction
-    pub fn write_file<S: AsRef<Path>>(
-        mut self,
-        source: S,
-        temp_dir: S,
-        data: Vec<u8>,
-    ) -> Transaction {
+    /// Adds a [`WriteFile`] operation.
+    pub fn write_file<S: AsRef<Path>>(mut self, path: S, data: Vec<u8>) -> Self {
         self.ops
-            .push(Box::new(WriteFile::new(source, temp_dir, data)));
+            .push(Box::new(WriteFile::with_temp_dir(path, self.temp_dir.clone(), data)));
+        self
+    }
+
+    /// Adds a [`TouchFile`] operation.
+    pub fn touch_file<S: AsRef<Path>>(mut self, path: S) -> Self {
+        self.ops.push(Box::new(TouchFile::new(path)));
         self
     }
 }
 
-impl RollbackableOperation for Transaction {
-    /// Executes the transaction
-    fn execute(&mut self) -> io::Result<()> {
-        for i in 0..self.ops.len() {
-            self.execution_count += 1;
-            if let Err(e) = self.ops[i].execute() {
-                return Err(e);
-            }
-        }
+impl Default for Transaction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
+impl RollbackableOperation for Transaction {
+    /// Executes all operations in order, stopping at the first error.
+    fn execute(&mut self) -> io::Result<()> {
+        self.execution_count = 0;
+        for i in 0..self.ops.len() {
+            self.ops[i].execute()?;
+            self.execution_count += 1;
+        }
         Ok(())
     }
 
-    /// Performs rollback on the transaction
+    /// Rolls back all executed operations in reverse order, then resets the counter.
     ///
-    /// Only the operations that were executed will be rollbacked
-    fn rollback(&self) -> io::Result<()> {
+    /// Only the operations that completed successfully are rolled back.
+    fn rollback(&mut self) -> io::Result<()> {
         for i in (0..self.execution_count).rev() {
-            if let Err(e) = self.ops[i].rollback() {
-                return Err(e);
-            }
+            self.ops[i].rollback()?;
         }
-
+        self.execution_count = 0;
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::*;
 
     #[test]
-    #[allow(unused)]
     fn transaction_works() {
-        let temp_dir = "./tmp";
-        let mut tr = Transaction::new()
-            .create_file("./created_file_transaction.txt")
-            .create_file("./for_delete.txt")
-            .create_dir("./inner/create_dir_transaction")
-            .create_dir("./for_delete_dir")
-            .create_dir("./magic_dir")
-            .write_file(
-                "./created_file_transaction.txt",
-                temp_dir,
-                b"Hello World".to_vec(),
-            )
-            .append_file(
-                "./created_file_transaction.txt",
-                temp_dir,
-                b"Hello World".to_vec(),
-            )
-            .copy_file(
-                "./created_file_transaction.txt",
-                "./inner/created_file_transaction.txt",
-            )
-            .copy_dir("./magic_dir", "./inner/magic_dir", temp_dir)
-            .delete_file("./for_delete.txt", temp_dir)
-            .delete_dir("./for_delete_dir", temp_dir)
-            .move_file(
-                "./inner/created_file_transaction.txt",
-                "./inner/magic_dir/created_file_transaction.txt",
-            )
-            .create_dir("./for_moving")
-            .move_dir("./for_moving", "./inner/magic_dir/for_moving");
+        let dir = tempdir().unwrap();
+        let d = dir.path();
 
-        assert_eq!((), tr.execute().expect("Cannot execute"));
-        assert_eq!((), tr.rollback().expect("Cannot Rollback"));
+        let mut tr = Transaction::with_temp_dir(d)
+            .create_file(d.join("file.txt"))
+            .create_file(d.join("for_delete.txt"))
+            .create_dir(d.join("inner/sub"))
+            .create_dir(d.join("for_delete_dir"))
+            .create_dir(d.join("magic_dir"))
+            .write_file(d.join("file.txt"), b"Hello World".to_vec())
+            .append_file(d.join("file.txt"), b"Hello World".to_vec())
+            .copy_file(d.join("file.txt"), d.join("inner/file.txt"))
+            .copy_dir(d.join("magic_dir"), d.join("inner/magic_dir"))
+            .delete_file(d.join("for_delete.txt"))
+            .delete_dir(d.join("for_delete_dir"))
+            .move_file(d.join("inner/file.txt"), d.join("inner/magic_dir/file.txt"))
+            .create_dir(d.join("for_moving"))
+            .move_dir(d.join("for_moving"), d.join("inner/magic_dir/for_moving"));
+
+        tr.execute().expect("Cannot execute");
+        tr.rollback().expect("Cannot rollback");
     }
 }

--- a/src/move.rs
+++ b/src/move.rs
@@ -4,110 +4,123 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::RollbackableOperation;
+use crate::{copy_dir, RollbackableOperation};
 
-/// Moves a file from source to destination. A type alias for [MoveOperation](MoveOperation) for consistency in the API
+/// Moves a file from source to destination. Type alias for [`MoveOperation`] for API consistency.
 pub type MoveFile = MoveOperation;
 
-/// Moves a directory from source to destination. A type alias for [MoveOperation](MoveOperation) for consistency in the API
+/// Moves a directory from source to destination. Type alias for [`MoveOperation`] for API consistency.
 pub type MoveDirectory = MoveOperation;
 
-/// Move operation
+/// Move operation (works for both files and directories).
 ///
-/// This is a type-independent operation ie. it works with both files and directories since [std::fs::rename](std::fs::rename) is also independent
+/// Attempts `fs::rename` first. On `ErrorKind::CrossesDevices`, automatically falls back to
+/// copy-then-delete. Rollback uses the same strategy in reverse.
 pub struct MoveOperation {
     source: PathBuf,
     dest: PathBuf,
+    was_cross_device: bool,
 }
 
 impl MoveOperation {
-    /// Constructs a new MoveOperation operation
-    ///
-    /// This operation is directly called by [MoveFile](MoveFile) and [MoveDirectory](MoveDirectory) and hence only available as a single operation
+    /// Constructs a new `MoveOperation`.
     pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, dest: T) -> Self {
         Self {
             source: source.as_ref().into(),
             dest: dest.as_ref().into(),
+            was_cross_device: false,
         }
     }
 }
 
 impl RollbackableOperation for MoveOperation {
     fn execute(&mut self) -> io::Result<()> {
-        fs::rename(&self.source, &self.dest)
+        match fs::rename(&self.source, &self.dest) {
+            Ok(()) => {
+                self.was_cross_device = false;
+                Ok(())
+            }
+            Err(e) if e.kind() == io::ErrorKind::CrossesDevices => {
+                self.was_cross_device = true;
+                cross_device_move(&self.source, &self.dest)
+            }
+            Err(e) => Err(e),
+        }
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        fs::rename(&self.dest, &self.source)
+    fn rollback(&mut self) -> io::Result<()> {
+        let result = if self.was_cross_device {
+            cross_device_move(&self.dest, &self.source)
+        } else {
+            fs::rename(&self.dest, &self.source)
+        };
+        match result {
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            other => other,
+        }
+    }
+}
+
+fn cross_device_move(from: &Path, to: &Path) -> io::Result<()> {
+    if from.is_dir() {
+        copy_dir(from, to)?;
+        fs::remove_dir_all(from)
+    } else {
+        fs::copy(from, to).map(|_| ())?;
+        fs::remove_file(from)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, File};
-    use std::path::Path;
+    use std::fs;
+
+    use tempfile::tempdir;
 
     use super::*;
 
-    const FILE_SOURCE: &str = "./move_file_source.txt";
-    const FILE_DEST_DIR: &str = "./move_file_out_dir";
-    const FILE_DEST: &str = "./move_file_out_dir/move_file_source.txt";
-
-    fn file_setup() -> std::io::Result<()> {
-        File::create(FILE_SOURCE)?;
-        fs::create_dir_all(FILE_DEST_DIR)
-    }
-
     #[test]
-    #[allow(unused_must_use)]
     fn move_file_works() {
-        assert_eq!((), file_setup().unwrap());
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("source.txt");
+        let dest_dir = dir.path().join("out_dir");
+        let dest = dest_dir.join("source.txt");
+        fs::write(&src, b"data").unwrap();
+        fs::create_dir(&dest_dir).unwrap();
 
-        let mut op = MoveFile::new(FILE_SOURCE, FILE_DEST);
+        let mut op = MoveFile::new(&src, &dest);
+        assert!(src.exists());
+        assert!(!dest.exists());
 
-        assert_eq!(true, Path::new(FILE_SOURCE).exists());
-        assert_eq!(false, Path::new(FILE_DEST).exists());
+        op.execute().unwrap();
+        assert!(!src.exists());
+        assert!(dest.exists());
 
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(false, Path::new(FILE_SOURCE).exists());
-        assert_eq!(true, Path::new(FILE_DEST).exists());
-
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(true, Path::new(FILE_SOURCE).exists());
-        assert_eq!(false, Path::new(FILE_DEST).exists());
-
-        fs::remove_file(FILE_SOURCE);
-        fs::remove_dir_all(FILE_DEST_DIR);
-    }
-
-    const DIR_SOURCE: &str = "./move_dir_source";
-    const DIR_DIR: &str = "./move_dir_dest_dir";
-    const DIR_DEST: &str = "./move_dir_dest_dir/move_dir_source";
-
-    fn dir_setup() -> std::io::Result<()> {
-        fs::create_dir_all(DIR_SOURCE)?;
-        fs::create_dir_all(DIR_DIR)
+        op.rollback().unwrap();
+        assert!(src.exists());
+        assert!(!dest.exists());
     }
 
     #[test]
-    #[allow(unused_must_use)]
     fn move_dir_works() {
-        assert_eq!((), dir_setup().unwrap());
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_dir");
+        let dest_parent = dir.path().join("dest_parent");
+        let dest = dest_parent.join("src_dir");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("file.txt"), b"hello").unwrap();
+        fs::create_dir_all(&dest_parent).unwrap();
 
-        let mut op = MoveDirectory::new(DIR_SOURCE, DIR_DEST);
+        let mut op = MoveDirectory::new(&src, &dest);
+        assert!(src.exists());
+        assert!(!dest.exists());
 
-        assert_eq!(true, Path::new(DIR_SOURCE).exists());
-        assert_eq!(false, Path::new(DIR_DEST).exists());
+        op.execute().unwrap();
+        assert!(!src.exists());
+        assert!(dest.exists());
 
-        assert_eq!((), op.execute().unwrap());
-        assert_eq!(false, Path::new(DIR_SOURCE).exists());
-        assert_eq!(true, Path::new(DIR_DEST).exists());
-
-        assert_eq!((), op.rollback().unwrap());
-        assert_eq!(true, Path::new(DIR_SOURCE).exists());
-        assert_eq!(false, Path::new(DIR_DEST).exists());
-
-        fs::remove_dir_all(DIR_SOURCE);
-        fs::remove_dir_all(DIR_DIR);
+        op.rollback().unwrap();
+        assert!(src.exists());
+        assert!(!dest.exists());
     }
 }

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -1,0 +1,127 @@
+use std::fs::{File, FileTimes, OpenOptions};
+use std::time::SystemTime;
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use crate::RollbackableOperation;
+
+enum TouchState {
+    NotExecuted,
+    /// File did not exist before execute(); rollback deletes it.
+    Created,
+    /// File existed; rollback restores its original access + modification times.
+    Touched {
+        original_accessed: SystemTime,
+        original_modified: SystemTime,
+    },
+}
+
+/// Creates a file if it does not exist, or updates its access and modification times to now
+pub struct TouchFile {
+    path: PathBuf,
+    state: TouchState,
+}
+
+impl TouchFile {
+    /// Constructs a new TouchFile operation
+    pub fn new<S: AsRef<Path>>(path: S) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            state: TouchState::NotExecuted,
+        }
+    }
+}
+
+impl RollbackableOperation for TouchFile {
+    fn execute(&mut self) -> io::Result<()> {
+        if self.path.exists() {
+            let meta = std::fs::metadata(&self.path)?;
+            let original_accessed = meta.accessed()?;
+            let original_modified = meta.modified()?;
+            self.state = TouchState::Touched {
+                original_accessed,
+                original_modified,
+            };
+            OpenOptions::new()
+                .write(true)
+                .open(&self.path)?
+                .set_times(FileTimes::new().set_accessed(SystemTime::now()).set_modified(SystemTime::now()))
+        } else {
+            File::create(&self.path)?;
+            self.state = TouchState::Created;
+            Ok(())
+        }
+    }
+
+    fn rollback(&mut self) -> io::Result<()> {
+        match &self.state {
+            TouchState::NotExecuted => Ok(()),
+            TouchState::Created => std::fs::remove_file(&self.path),
+            TouchState::Touched {
+                original_accessed,
+                original_modified,
+            } => OpenOptions::new()
+                .write(true)
+                .open(&self.path)?
+                .set_times(
+                    FileTimes::new()
+                        .set_accessed(*original_accessed)
+                        .set_modified(*original_modified),
+                ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::Duration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn touch_creates_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("new_file.txt");
+
+        assert!(!path.exists());
+        let mut op = TouchFile::new(&path);
+        op.execute().unwrap();
+        assert!(path.exists());
+
+        op.rollback().unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn touch_updates_mtime_and_restores() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("existing.txt");
+        fs::write(&path, b"data").unwrap();
+
+        // Set a known old mtime (1 second in the past)
+        let past = SystemTime::now() - Duration::from_secs(10);
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(FileTimes::new().set_accessed(past).set_modified(past))
+            .unwrap();
+
+        let original_mtime = fs::metadata(&path).unwrap().modified().unwrap();
+
+        let mut op = TouchFile::new(&path);
+        op.execute().unwrap();
+
+        let new_mtime = fs::metadata(&path).unwrap().modified().unwrap();
+        assert!(new_mtime > original_mtime);
+
+        op.rollback().unwrap();
+        let restored_mtime = fs::metadata(&path).unwrap().modified().unwrap();
+        assert_eq!(original_mtime, restored_mtime);
+    }
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,27 +1,33 @@
-use std::io::{self, Read, Write};
+use std::fs;
 use std::{
-    fs::OpenOptions,
+    env,
+    io,
     path::{Path, PathBuf},
 };
 
 use crate::{RollbackableOperation, SingleFileOperation};
 
-/// Writes data to a file
+/// Writes data to a file, replacing its existing contents.
 pub struct WriteFile {
-    source: PathBuf,
+    path: PathBuf,
     temp_dir: PathBuf,
     backup_path: PathBuf,
     data: Vec<u8>,
 }
 
 impl WriteFile {
-    /// Constructs a new WriteFile operation
-    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(source: S, temp_dir: T, data: Vec<u8>) -> Self {
+    /// Constructs a new `WriteFile` operation, using the OS temp directory for backups.
+    pub fn new<S: AsRef<Path>>(path: S, data: Vec<u8>) -> Self {
+        Self::with_temp_dir(path, env::temp_dir(), data)
+    }
+
+    /// Constructs a new `WriteFile` operation with a custom backup directory.
+    pub fn with_temp_dir<S: AsRef<Path>, T: AsRef<Path>>(path: S, temp_dir: T, data: Vec<u8>) -> Self {
         Self {
-            source: source.as_ref().into(),
+            path: path.as_ref().into(),
             temp_dir: temp_dir.as_ref().into(),
             backup_path: PathBuf::new(),
-            data: data,
+            data,
         }
     }
 }
@@ -29,38 +35,28 @@ impl WriteFile {
 impl RollbackableOperation for WriteFile {
     fn execute(&mut self) -> io::Result<()> {
         self.create_backup_file()?;
-
-        OpenOptions::new()
-            .write(true)
-            .open(self.get_path())?
-            .write_all(&self.data)
+        fs::write(&self.path, &self.data)
     }
 
-    fn rollback(&self) -> io::Result<()> {
-        let mut buffer = Vec::<u8>::new();
-        let mut backup_file = OpenOptions::new().read(true).open(self.get_backup_path())?;
-
-        backup_file.read_to_end(&mut buffer)?;
-
-        OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(self.get_path())?
-            .write_all(&buffer)
+    fn rollback(&mut self) -> io::Result<()> {
+        if self.backup_path.as_os_str().is_empty() {
+            return Ok(());
+        }
+        fs::copy(&self.backup_path, &self.path).map(|_| ())
     }
 }
 
 impl SingleFileOperation for WriteFile {
     fn get_path(&self) -> &Path {
-        &self.source
+        &self.path
     }
 
     fn get_backup_path(&self) -> &Path {
         &self.backup_path
     }
 
-    fn set_backup_path<S: AsRef<Path>>(&mut self, uuid: S) {
-        self.backup_path = uuid.as_ref().into();
+    fn set_backup_path<S: AsRef<Path>>(&mut self, path: S) {
+        self.backup_path = path.as_ref().into();
     }
 
     fn get_temp_dir(&self) -> &Path {
@@ -70,48 +66,46 @@ impl SingleFileOperation for WriteFile {
 
 impl Drop for WriteFile {
     fn drop(&mut self) {
-        match self.dispose() {
-            Err(e) => eprintln!("{}", e),
-            _ => {}
+        if let Err(e) = self.dispose() {
+            eprintln!("{}", e);
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, File};
+    use std::fs;
+
+    use tempfile::tempdir;
 
     use super::*;
 
-    const FILE_SOURCE: &str = "./write_file_source.txt";
-    const TEMP_DIR: &str = "./tmp/";
-    const INITIAL_DATA: &[u8] = "Yellow World".as_bytes();
-    const WRITTEN_DATA: &[u8] = "Hello World".as_bytes();
+    const INITIAL_DATA: &[u8] = b"Yellow World";
+    const WRITTEN_DATA: &[u8] = b"Hello World";
 
-    fn write_setup() -> std::io::Result<()> {
-        match File::create(FILE_SOURCE) {
-            Ok(_f) => Ok(()),
-            Err(e) => Err(e),
-        }
+    #[test]
+    fn write_file_works() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("write_file.txt");
+        fs::write(&file_path, INITIAL_DATA).unwrap();
+
+        let mut op = WriteFile::with_temp_dir(&file_path, dir.path(), WRITTEN_DATA.to_vec());
+
+        op.execute().expect("Unable to perform execute");
+        assert_eq!(WRITTEN_DATA, fs::read(&file_path).unwrap().as_slice());
+
+        op.rollback().expect("Unable to perform rollback");
+        assert_eq!(INITIAL_DATA, fs::read(&file_path).unwrap().as_slice());
     }
 
     #[test]
-    #[allow(unused_must_use)]
-    fn write_file_works() {
-        assert_eq!((), write_setup().unwrap());
+    fn rollback_before_execute_is_noop() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("write_noop.txt");
+        fs::write(&file_path, INITIAL_DATA).unwrap();
 
-        fs::write(FILE_SOURCE, INITIAL_DATA).expect("Unable to write file");
-
-        let mut op = WriteFile::new(FILE_SOURCE, TEMP_DIR, WRITTEN_DATA.to_vec());
-
-        assert_eq!((), op.execute().unwrap());
-        let data = fs::read_to_string(FILE_SOURCE).expect("Unable to read file");
-        assert_eq!(String::from("Hello Worldd"), data);
-
-        assert_eq!((), op.rollback().unwrap());
-        let data = fs::read_to_string(FILE_SOURCE).expect("Unable to read file");
-        assert_eq!(String::from_utf8(INITIAL_DATA.to_vec()).unwrap(), data);
-
-        fs::remove_file(FILE_SOURCE);
+        let mut op = WriteFile::with_temp_dir(&file_path, dir.path(), WRITTEN_DATA.to_vec());
+        op.rollback().expect("rollback before execute should be a no-op");
+        assert_eq!(INITIAL_DATA, fs::read(&file_path).unwrap().as_slice());
     }
 }


### PR DESCRIPTION
## Summary

- **Bug fixes** — `rollback()` is now safe to call even when `execute()` never ran or failed partway through; `DeleteDirectory::rollback` gets cross-device fallback; `Transaction::execute` only counts successfully completed ops; `MoveOperation::rollback` handles `NotFound` gracefully; `CreateFile` fails (instead of silently truncating) when target exists
- **Breaking API** — `rollback(&self)` → `rollback(&mut self)` (removes `Cell`/`AtomicUsize` interior-mutability hacks); `CopyFile`/`CopyDirectory` back up a pre-existing destination and restore it on rollback; all backup-needing ops get `new()` (OS temp dir default) + `with_temp_dir()` for explicit control
- **async-trait removed** — trait returns `Pin<Box<dyn Future + Send + '_>>` directly; MSRV raised to 1.85; all async types re-exported at the crate root under the `tokio` feature so `use tfio::async_::*` is no longer needed
- **Performance / quality** — `AppendFile`/`WriteFile` rollback uses `fs::copy` instead of read-buffer-write; `copy_dir` uses `entry.file_type()` to skip extra `stat`; async `Drop` helpers deduplicated; `AsyncTouchFile` `set_times` moved into `spawn_blocking`

## Test plan

- [x] `cargo test` — 22 unit tests pass
- [x] `cargo test --features tokio` — all 22 tests pass including async integration test
- [x] `cargo test --doc --features tokio` — 2 doc examples compile and pass
- [x] `cargo run --example transaction`
- [x] `cargo run --example rollback_on_error`
- [x] `cargo run --example async_transaction --features tokio`